### PR TITLE
Skip experiment when hashAttribute's value is `None`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ test_requirements = ['pytest>=3', ]
 
 setup(
     name='growthbook',
-    version='0.3.0',
+    version='0.3.1',
     author="GrowthBook",
     author_email='hello@growthbook.io',
     python_requires='>=3.6',

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.2",
+  "specVersion": "0.2.1",
   "evalCondition": [
     [
       "$not - pass",

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -1,4 +1,5 @@
 {
+  "specVersion": "0.2",
   "evalCondition": [
     [
       "$not - pass",
@@ -1704,6 +1705,7 @@
           "variations": ["a", "b", "c"]
         },
         "experimentResult": {
+          "featureId": "feature",
           "value": "c",
           "variationId": 2,
           "inExperiment": true,
@@ -1740,6 +1742,7 @@
           "variations": ["a", "b", "c"]
         },
         "experimentResult": {
+          "featureId": "feature",
           "value": "a",
           "variationId": 0,
           "inExperiment": true,
@@ -1776,6 +1779,7 @@
           "variations": ["a", "b", "c"]
         },
         "experimentResult": {
+          "featureId": "feature",
           "value": "b",
           "variationId": 1,
           "inExperiment": true,
@@ -1824,6 +1828,7 @@
           "weights": [0.1, 0.9]
         },
         "experimentResult": {
+          "featureId": "feature",
           "value": false,
           "variationId": 1,
           "inExperiment": true,
@@ -2048,6 +2053,7 @@
           "variations": [0, 1, 2, 3]
         },
         "experimentResult": {
+          "featureId": "feature",
           "value": 1,
           "variationId": 1,
           "inExperiment": true,
@@ -2366,6 +2372,14 @@
     [
       "empty id",
       { "attributes": { "id": "" } },
+      { "key": "my-test", "variations": [0, 1] },
+      0,
+      false,
+      false
+    ],
+    [
+      "null id",
+      { "attributes": { "id": null } },
       { "key": "my-test", "variations": [0, 1] },
       0,
       false,


### PR DESCRIPTION
Currently, attributes are cast to a string before being used for hashing.  In Python null (`None`) is cast to `"None"` which is indistinguishable from a real user id.  If the attribute value is null, it should result in an empty string instead, which this PR fixes.

This PR also brings the Python SDK into alignment with the latest SDK spec version 0.2.1.  Notably, this means the Result of an experiment now contains the `featureId` (if any) that triggered the experiment.