### PR TITLE
Set debug level for tests

### DIFF
--- a/growthbook.py
+++ b/growthbook.py
@@ -867,7 +867,9 @@ class GrowthBook(object):
             self._fireSubscriptions(exp, result)
 
             if not result.inExperiment:
-                logger.debug("Skip rule because user not included in experiment", key)
+                logger.debug(
+                    "Skip rule because user not included in experiment, feature %s", key
+                )
                 continue
 
             if result.passthrough:

--- a/tests/test_growthbook.py
+++ b/tests/test_growthbook.py
@@ -16,9 +16,12 @@ from growthbook import (
     evalCondition,
     decrypt,
     feature_repo,
+    logger,
 )
 from time import time
 import pytest
+
+logger.setLevel("DEBUG")
 
 
 def pytest_generate_tests(metafunc):


### PR DESCRIPTION
There was an error in one of our debug statements, however the tests were not triggering it because the logger level by default was above debug.  

This change:
- Sets the logging level for tests, which caused three tests to fail.  
- So then we also fixed the test, by fixing the `logger.debug` line.

