### PR TITLE
Add support for ruleId output in eval_feature

### DIFF
--- a/growthbook.py
+++ b/growthbook.py
@@ -454,6 +454,7 @@ class Feature(object):
 class FeatureRule(object):
     def __init__(
         self,
+        id: str = None,
         key: str = "",
         variations: list = None,
         weights: List[float] = None,
@@ -471,6 +472,7 @@ class FeatureRule(object):
         name: str = None,
         phase: str = None,
     ) -> None:
+        self.id = id
         self.key = key
         self.variations = variations
         self.weights = weights
@@ -490,6 +492,8 @@ class FeatureRule(object):
 
     def to_dict(self) -> dict:
         data: Dict[str, Any] = {}
+        if self.id:
+            data["id"] = self.id
         if self.key:
             data["key"] = self.key
         if self.variations is not None:
@@ -533,9 +537,11 @@ class FeatureResult(object):
         source: str,
         experiment: Experiment = None,
         experimentResult: Result = None,
+        ruleId: str = None,
     ) -> None:
         self.value = value
         self.source = source
+        self.ruleId = ruleId
         self.experiment = experiment
         self.experimentResult = experimentResult
         self.on = bool(value)
@@ -548,6 +554,8 @@ class FeatureResult(object):
             "on": self.on,
             "off": self.off,
         }
+        if self.ruleId:
+            data["ruleId"] = self.ruleId
         if self.experiment:
             data["experiment"] = self.experiment.to_dict()
         if self.experimentResult:
@@ -841,7 +849,7 @@ class GrowthBook(object):
                     continue
 
                 logger.debug("Force value from rule, feature %s", key)
-                return FeatureResult(rule.force, "force")
+                return FeatureResult(rule.force, "force", ruleId=rule.id)
 
             if rule.variations is None:
                 logger.warning("Skip invalid rule, feature %s", key)
@@ -877,7 +885,9 @@ class GrowthBook(object):
                 continue
 
             logger.debug("Assign value from experiment, feature %s", key)
-            return FeatureResult(result.value, "experiment", exp, result)
+            return FeatureResult(
+                result.value, "experiment", exp, result, ruleId=rule.id
+            )
 
         logger.debug("Use default value for feature %s", key)
         return FeatureResult(feature.defaultValue, "defaultValue")
@@ -1131,9 +1141,7 @@ class GrowthBook(object):
         self._track(experiment, result)
 
         # 15. Return the result
-        logger.debug(
-            "Assigned variation %d in experiment %s", assigned, experiment.key
-        )
+        logger.debug("Assigned variation %d in experiment %s", assigned, experiment.key)
         return result
 
     def _track(self, experiment: Experiment, result: Result) -> None:

--- a/tests/test_growthbook.py
+++ b/tests/test_growthbook.py
@@ -98,7 +98,7 @@ def test_decrypt(decrypt_data):
     _, encrypted, key, expected = decrypt_data
     try:
         assert (decrypt(encrypted, key)) == expected
-    except(Exception):
+    except Exception:
         assert (expected) is None
 
 
@@ -566,6 +566,14 @@ def test_getters_setters():
     gb.setAttributes(newAttrs)
     assert newAttrs == gb.getAttributes()
 
+    gb.destroy()
+
+
+def test_return_ruleid_when_evaluating_a_feature():
+    gb = GrowthBook(
+        features={"feature": {"defaultValue": 0, "rules": [{"force": 1, "id": "foo"}]}}
+    )
+    assert gb.eval_feature("feature").ruleId == "foo"
     gb.destroy()
 
 


### PR DESCRIPTION
Closes https://github.com/growthbook/growthbook-python/issues/13.

The `ruleId` output value is available for both the Go and JS SDKs, this PR brings better feature parity to the Python SDK.