### PR TITLE
Update to spec 0.7.1, fix failing tests

### DIFF
--- a/growthbook/common_types.py
+++ b/growthbook/common_types.py
@@ -396,7 +396,7 @@ class AbstractStickyBucketService(ABC):
 @dataclass
 class StackContext: 
     id: Optional[str] = None
-    evaluted_features: Set[str] = field(default_factory=set)
+    evaluated_features: Set[str] = field(default_factory=set)
 
 class FeatureRefreshStrategy(Enum):
     STALE_WHILE_REVALIDATE = 'HTTP_REFRESH'

--- a/growthbook/growthbook.py
+++ b/growthbook/growthbook.py
@@ -641,7 +641,7 @@ class GrowthBook(object):
         return EvaluationContext(
             global_ctx = self._global_ctx,
             user = self._user_ctx,
-            stack = StackContext(evaluted_features=set())
+            stack = StackContext(evaluated_features=set())
         )
 
     def eval_feature(self, key: str) -> FeatureResult:

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -469,7 +469,7 @@ class GrowthBookClient:
         return EvaluationContext(
             user=user_context,
             global_ctx=self._global_context,
-            stack=StackContext(evaluted_features=set())
+            stack=StackContext(evaluated_features=set())
         )
 
     async def eval_feature(self, key: str, user_context: UserContext) -> FeatureResult:

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.5.4",
+  "specVersion": "0.7.1",
   "evalCondition": [
     [
       "$not - pass",
@@ -63,32 +63,24 @@
         "$and": [
           {
             "$groups": {
-              "$elemMatch": {
-                "$eq": "a"
-              }
+              "$elemMatch": { "$eq": "a" }
             }
           },
           {
             "$groups": {
-              "$elemMatch": {
-                "$eq": "b"
-              }
+              "$elemMatch": { "$eq": "b" }
             }
           },
           {
             "$or": [
               {
                 "$groups": {
-                  "$elemMatch": {
-                    "$eq": "c"
-                  }
+                  "$elemMatch": { "$eq": "c" }
                 }
               },
               {
                 "$groups": {
-                  "$elemMatch": {
-                    "$eq": "e"
-                  }
+                  "$elemMatch": { "$eq": "e" }
                 }
               }
             ]
@@ -96,30 +88,21 @@
           {
             "$not": {
               "$groups": {
-                "$elemMatch": {
-                  "$eq": "f"
-                }
+                "$elemMatch": { "$eq": "f" }
               }
             }
           },
           {
             "$not": {
               "$groups": {
-                "$elemMatch": {
-                  "$eq": "g"
-                }
+                "$elemMatch": { "$eq": "g" }
               }
             }
           }
         ]
       },
       {
-        "$groups": [
-          "a",
-          "b",
-          "c",
-          "d"
-        ]
+        "$groups": ["a", "b", "c", "d"]
       },
       true
     ],
@@ -129,32 +112,24 @@
         "$and": [
           {
             "$groups": {
-              "$elemMatch": {
-                "$eq": "a"
-              }
+              "$elemMatch": { "$eq": "a" }
             }
           },
           {
             "$groups": {
-              "$elemMatch": {
-                "$eq": "b"
-              }
+              "$elemMatch": { "$eq": "b" }
             }
           },
           {
             "$or": [
               {
                 "$groups": {
-                  "$elemMatch": {
-                    "$eq": "c"
-                  }
+                  "$elemMatch": { "$eq": "c" }
                 }
               },
               {
                 "$groups": {
-                  "$elemMatch": {
-                    "$eq": "e"
-                  }
+                  "$elemMatch": { "$eq": "e" }
                 }
               }
             ]
@@ -162,30 +137,21 @@
           {
             "$not": {
               "$groups": {
-                "$elemMatch": {
-                  "$eq": "d"
-                }
+                "$elemMatch": { "$eq": "d" }
               }
             }
           },
           {
             "$not": {
               "$groups": {
-                "$elemMatch": {
-                  "$eq": "g"
-                }
+                "$elemMatch": { "$eq": "g" }
               }
             }
           }
         ]
       },
       {
-        "$groups": [
-          "a",
-          "b",
-          "c",
-          "d"
-        ]
+        "$groups": ["a", "b", "c", "d"]
       },
       false
     ],
@@ -423,11 +389,7 @@
       "$in - pass",
       {
         "num": {
-          "$in": [
-            1,
-            2,
-            3
-          ]
+          "$in": [1, 2, 3]
         }
       },
       {
@@ -439,11 +401,7 @@
       "$in - fail",
       {
         "num": {
-          "$in": [
-            1,
-            2,
-            3
-          ]
+          "$in": [1, 2, 3]
         }
       },
       {
@@ -467,18 +425,11 @@
       "$in - array pass 1",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "a"
-        ]
+        "tags": ["d", "e", "a"]
       },
       true
     ],
@@ -486,18 +437,11 @@
       "$in - array pass 2",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "f"
-        ]
+        "tags": ["d", "b", "f"]
       },
       true
     ],
@@ -505,18 +449,11 @@
       "$in - array pass 3",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "a"
-        ]
+        "tags": ["d", "b", "a"]
       },
       true
     ],
@@ -524,18 +461,11 @@
       "$in - array fail 1",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "f"
-        ]
+        "tags": ["d", "e", "f"]
       },
       false
     ],
@@ -543,10 +473,7 @@
       "$in - array fail 2",
       {
         "tags": {
-          "$in": [
-            "a",
-            "b"
-          ]
+          "$in": ["a", "b"]
         }
       },
       {
@@ -558,11 +485,7 @@
       "$nin - pass",
       {
         "num": {
-          "$nin": [
-            1,
-            2,
-            3
-          ]
+          "$nin": [1, 2, 3]
         }
       },
       {
@@ -574,11 +497,7 @@
       "$nin - fail",
       {
         "num": {
-          "$nin": [
-            1,
-            2,
-            3
-          ]
+          "$nin": [1, 2, 3]
         }
       },
       {
@@ -602,18 +521,11 @@
       "$nin - array fail 1",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "a"
-        ]
+        "tags": ["d", "e", "a"]
       },
       false
     ],
@@ -621,18 +533,11 @@
       "$nin - array fail 2",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "f"
-        ]
+        "tags": ["d", "b", "f"]
       },
       false
     ],
@@ -640,18 +545,11 @@
       "$nin - array fail 3",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "b",
-          "a"
-        ]
+        "tags": ["d", "b", "a"]
       },
       false
     ],
@@ -659,18 +557,11 @@
       "$nin - array pass 1",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "f"
-        ]
+        "tags": ["d", "e", "f"]
       },
       true
     ],
@@ -678,10 +569,7 @@
       "$nin - array pass 2",
       {
         "tags": {
-          "$nin": [
-            "a",
-            "b"
-          ]
+          "$nin": ["a", "b"]
         }
       },
       {
@@ -699,12 +587,7 @@
         }
       },
       {
-        "nums": [
-          0,
-          5,
-          -20,
-          15
-        ]
+        "nums": [0, 5, -20, 15]
       },
       true
     ],
@@ -718,12 +601,7 @@
         }
       },
       {
-        "nums": [
-          0,
-          5,
-          -20,
-          8
-        ]
+        "nums": [0, 5, -20, 8]
       },
       false
     ],
@@ -731,9 +609,7 @@
       "missing attribute - fail",
       {
         "pets.dog.name": {
-          "$in": [
-            "fido"
-          ]
+          "$in": ["fido"]
         }
       },
       {
@@ -1187,10 +1063,7 @@
         }
       },
       {
-        "a": [
-          1,
-          2
-        ]
+        "a": [1, 2]
       },
       true
     ],
@@ -1245,9 +1118,7 @@
     [
       "$size empty - pass",
       {
-        "tags": {
-          "$size": 0
-        }
+        "tags": { "$size": 0 }
       },
       {
         "tags": []
@@ -1257,14 +1128,10 @@
     [
       "$size empty - fail",
       {
-        "tags": {
-          "$size": 0
-        }
+        "tags": { "$size": 0 }
       },
       {
-        "tags": [
-          10
-        ]
+        "tags": [10]
       },
       false
     ],
@@ -1276,11 +1143,7 @@
         }
       },
       {
-        "tags": [
-          "a",
-          "b",
-          "c"
-        ]
+        "tags": ["a", "b", "c"]
       },
       true
     ],
@@ -1292,10 +1155,7 @@
         }
       },
       {
-        "tags": [
-          "a",
-          "b"
-        ]
+        "tags": ["a", "b"]
       },
       false
     ],
@@ -1307,12 +1167,7 @@
         }
       },
       {
-        "tags": [
-          "a",
-          "b",
-          "c",
-          "d"
-        ]
+        "tags": ["a", "b", "c", "d"]
       },
       false
     ],
@@ -1338,11 +1193,7 @@
         }
       },
       {
-        "tags": [
-          0,
-          1,
-          2
-        ]
+        "tags": [0, 1, 2]
       },
       true
     ],
@@ -1356,10 +1207,7 @@
         }
       },
       {
-        "tags": [
-          0,
-          1
-        ]
+        "tags": [0, 1]
       },
       false
     ],
@@ -1373,9 +1221,7 @@
         }
       },
       {
-        "tags": [
-          0
-        ]
+        "tags": [0]
       },
       false
     ],
@@ -1389,11 +1235,7 @@
         }
       },
       {
-        "tags": [
-          "foo",
-          "bar",
-          "baz"
-        ]
+        "tags": ["foo", "bar", "baz"]
       },
       true
     ],
@@ -1407,10 +1249,7 @@
         }
       },
       {
-        "tags": [
-          "foo",
-          "baz"
-        ]
+        "tags": ["foo", "baz"]
       },
       false
     ],
@@ -1419,19 +1258,12 @@
       {
         "tags": {
           "$elemMatch": {
-            "$in": [
-              "a",
-              "b"
-            ]
+            "$in": ["a", "b"]
           }
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "b"
-        ]
+        "tags": ["d", "e", "b"]
       },
       true
     ],
@@ -1440,19 +1272,12 @@
       {
         "tags": {
           "$elemMatch": {
-            "$in": [
-              "a",
-              "b"
-            ]
+            "$in": ["a", "b"]
           }
         }
       },
       {
-        "tags": [
-          "d",
-          "e",
-          "f"
-        ]
+        "tags": ["d", "e", "f"]
       },
       false
     ],
@@ -1468,10 +1293,7 @@
         }
       },
       {
-        "tags": [
-          "foo",
-          "baz"
-        ]
+        "tags": ["foo", "baz"]
       },
       true
     ],
@@ -1487,11 +1309,7 @@
         }
       },
       {
-        "tags": [
-          "foo",
-          "bar",
-          "baz"
-        ]
+        "tags": ["foo", "bar", "baz"]
       },
       false
     ],
@@ -1592,18 +1410,11 @@
       "$all - pass",
       {
         "tags": {
-          "$all": [
-            "one",
-            "three"
-          ]
+          "$all": ["one", "three"]
         }
       },
       {
-        "tags": [
-          "one",
-          "two",
-          "three"
-        ]
+        "tags": ["one", "two", "three"]
       },
       true
     ],
@@ -1611,18 +1422,11 @@
       "$all - fail",
       {
         "tags": {
-          "$all": [
-            "one",
-            "three"
-          ]
+          "$all": ["one", "three"]
         }
       },
       {
-        "tags": [
-          "one",
-          "two",
-          "four"
-        ]
+        "tags": ["one", "two", "four"]
       },
       false
     ],
@@ -1630,10 +1434,7 @@
       "$all - fail not array",
       {
         "tags": {
-          "$all": [
-            "one",
-            "three"
-          ]
+          "$all": ["one", "three"]
         }
       },
       {
@@ -1724,74 +1525,47 @@
     [
       "equals array - pass",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       true
     ],
     [
       "equals array - fail order",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
-        "tags": [
-          "world",
-          "hello"
-        ]
+        "tags": ["world", "hello"]
       },
       false
     ],
     [
       "equals array - fail missing item",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
-        "tags": [
-          "hello"
-        ]
+        "tags": ["hello"]
       },
       false
     ],
     [
       "equals array - fail extra item",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
-        "tags": [
-          "hello",
-          "world",
-          "foo"
-        ]
+        "tags": ["hello", "world", "foo"]
       },
       false
     ],
     [
       "equals array - fail type mismatch",
       {
-        "tags": [
-          "hello",
-          "world"
-        ]
+        "tags": ["hello", "world"]
       },
       {
         "tags": "hello world"
@@ -1897,6 +1671,32 @@
       {
         "userId": ""
       },
+      false
+    ],
+    [
+      "null condition - false attribute",
+      {
+        "userId": null
+      },
+      {
+        "userId": false
+      },
+      false
+    ],
+    [
+      "false condition - missing attribute",
+      {
+        "userId": false
+      },
+      {},
+      false
+    ],
+    [
+      "false strict condition - missing attribute",
+      {
+        "userId": { "$eq": false }
+      },
+      {},
       false
     ],
     [
@@ -3003,531 +2803,257 @@
       true
     ],
     [
+      "$or pass but second condition fail",
+      {
+        "$or": [{ "foo": 1 }, { "bar": 1 }],
+        "baz": 2
+      },
+      {
+        "foo": 1,
+        "bar": 2,
+        "baz": 1
+      },
+      false
+    ],
+    [
+      "$or and second condition both pass",
+      {
+        "$or": [{ "foo": 1 }, { "bar": 1 }],
+        "baz": 2
+      },
+      {
+        "foo": 1,
+        "bar": 2,
+        "baz": 2
+      },
+      true
+    ],
+    [
+      "$and condition pass but $or fail",
+      {
+        "$and": [{ "foo": 1 }, { "bar": 1 }],
+        "$or": [{ "baz": 1 }, { "empty": 1 }]
+      },
+      {
+        "foo": 1,
+        "bar": 1,
+        "baz": 2
+      },
+      false
+    ],
+    [
+      "$and and $or both pass",
+      {
+        "$and": [{ "foo": 1 }, { "bar": 1 }],
+        "$or": [{ "baz": 1 }, { "empty": 1 }]
+      },
+      {
+        "foo": 1,
+        "bar": 1,
+        "baz": 2,
+        "empty": 1
+      },
+      true
+    ],
+    [
       "$inGroup passes for member of known group id",
       {
-        "id": {
-          "$inGroup": "group_id"
-        }
+        "id": { "$inGroup": "group_id" }
       },
-      {
-        "id": 1
-      },
+      { "id": 1 },
       true,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$inGroup fails for non-member of known group id",
       {
-        "id": {
-          "$inGroup": "group_id"
-        }
+        "id": { "$inGroup": "group_id" }
       },
-      {
-        "id": 5
-      },
+      { "id": 5 },
       false,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$inGroup fails for unknown group id",
       {
-        "id": {
-          "$inGroup": "unknowngroup_id"
-        }
+        "id": { "$inGroup": "unknowngroup_id" }
       },
-      {
-        "id": 1
-      },
+      { "id": 1 },
       false,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$notInGroup fails for member of known group id",
       {
-        "id": {
-          "$notInGroup": "group_id"
-        }
+        "id": { "$notInGroup": "group_id" }
       },
-      {
-        "id": 1
-      },
+      { "id": 1 },
       false,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$notInGroup passes for non-member of known group id",
       {
-        "id": {
-          "$notInGroup": "group_id"
-        }
+        "id": { "$notInGroup": "group_id" }
       },
-      {
-        "id": 5
-      },
+      { "id": 5 },
       true,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$notInGroup passes for unknown group id",
       {
-        "id": {
-          "$notInGroup": "unknowngroup_id"
-        }
+        "id": { "$notInGroup": "unknowngroup_id" }
       },
-      {
-        "id": 1
-      },
+      { "id": 1 },
       true,
-      {
-        "group_id": [
-          1,
-          2,
-          3
-        ]
-      }
+      { "group_id": [1, 2, 3] }
     ],
     [
       "$inGroup passes for properly typed data",
       {
-        "id": {
-          "$inGroup": "group_id"
-        }
+        "id": { "$inGroup": "group_id" }
       },
-      {
-        "id": "2"
-      },
+      { "id": "2" },
       true,
-      {
-        "group_id": [
-          1,
-          "2",
-          3
-        ]
-      }
+      { "group_id": [1, "2", 3] }
     ],
     [
       "$inGroup fails for improperly typed data",
       {
-        "id": {
-          "$inGroup": "group_id"
-        }
+        "id": { "$inGroup": "group_id" }
       },
-      {
-        "id": "3"
-      },
+      { "id": "3" },
       false,
-      {
-        "group_id": [
-          1,
-          "2",
-          3
-        ]
-      }
+      { "group_id": [1, "2", 3] }
     ]
   ],
   "hash": [
-    [
-      "",
-      "a",
-      1,
-      0.22
-    ],
-    [
-      "",
-      "b",
-      1,
-      0.077
-    ],
-    [
-      "b",
-      "a",
-      1,
-      0.946
-    ],
-    [
-      "ef",
-      "d",
-      1,
-      0.652
-    ],
-    [
-      "asdf",
-      "8952klfjas09ujk",
-      1,
-      0.549
-    ],
-    [
-      "",
-      "123",
-      1,
-      0.011
-    ],
-    [
-      "",
-      "___)((*\":&",
-      1,
-      0.563
-    ],
-    [
-      "seed",
-      "a",
-      2,
-      0.0505
-    ],
-    [
-      "seed",
-      "b",
-      2,
-      0.2696
-    ],
-    [
-      "foo",
-      "ab",
-      2,
-      0.2575
-    ],
-    [
-      "foo",
-      "def",
-      2,
-      0.2019
-    ],
-    [
-      "89123klj",
-      "8952klfjas09ujkasdf",
-      2,
-      0.124
-    ],
-    [
-      "90850943850283058242805",
-      "123",
-      2,
-      0.7516
-    ],
-    [
-      "()**(%$##$%#$#",
-      "___)((*\":&",
-      2,
-      0.0128
-    ],
-    [
-      "abc",
-      "def",
-      99,
-      null
-    ]
+    ["", "a", 1, 0.22],
+    ["", "b", 1, 0.077],
+    ["b", "a", 1, 0.946],
+    ["ef", "d", 1, 0.652],
+    ["asdf", "8952klfjas09ujk", 1, 0.549],
+    ["", "123", 1, 0.011],
+    ["", "___)((*\":&", 1, 0.563],
+    ["seed", "a", 2, 0.0505],
+    ["seed", "b", 2, 0.2696],
+    ["foo", "ab", 2, 0.2575],
+    ["foo", "def", 2, 0.2019],
+    ["89123klj", "8952klfjas09ujkasdf", 2, 0.124],
+    ["90850943850283058242805", "123", 2, 0.7516],
+    ["()**(%$##$%#$#", "___)((*\":&", 2, 0.0128],
+    ["abc", "def", 99, null]
   ],
   "getBucketRange": [
     [
       "normal 50/50",
+      [2, 1, null],
       [
-        2,
-        1,
-        null
-      ],
-      [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "reduced coverage",
+      [2, 0.5, null],
       [
-        2,
-        0.5,
-        null
-      ],
-      [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ]
     ],
     [
       "zero coverage",
+      [2, 0, null],
       [
-        2,
-        0,
-        null
-      ],
-      [
-        [
-          0,
-          0
-        ],
-        [
-          0.5,
-          0.5
-        ]
+        [0, 0],
+        [0.5, 0.5]
       ]
     ],
     [
       "4 variations",
+      [4, 1, null],
       [
-        4,
-        1,
-        null
-      ],
-      [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.25,
-          0.5
-        ],
-        [
-          0.5,
-          0.75
-        ],
-        [
-          0.75,
-          1
-        ]
+        [0, 0.25],
+        [0.25, 0.5],
+        [0.5, 0.75],
+        [0.75, 1]
       ]
     ],
     [
       "uneven weights",
+      [2, 1, [0.4, 0.6]],
       [
-        2,
-        1,
-        [
-          0.4,
-          0.6
-        ]
-      ],
-      [
-        [
-          0,
-          0.4
-        ],
-        [
-          0.4,
-          1
-        ]
+        [0, 0.4],
+        [0.4, 1]
       ]
     ],
     [
       "uneven weights, 3 variations",
+      [3, 1, [0.2, 0.3, 0.5]],
       [
-        3,
-        1,
-        [
-          0.2,
-          0.3,
-          0.5
-        ]
-      ],
-      [
-        [
-          0,
-          0.2
-        ],
-        [
-          0.2,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.2],
+        [0.2, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "uneven weights, reduced coverage, 3 variations",
+      [3, 0.2, [0.2, 0.3, 0.5]],
       [
-        3,
-        0.2,
-        [
-          0.2,
-          0.3,
-          0.5
-        ]
-      ],
-      [
-        [
-          0,
-          0.04
-        ],
-        [
-          0.2,
-          0.26
-        ],
-        [
-          0.5,
-          0.6
-        ]
+        [0, 0.04],
+        [0.2, 0.26],
+        [0.5, 0.6]
       ]
     ],
     [
       "negative coverage",
+      [2, -0.2, null],
       [
-        2,
-        -0.2,
-        null
-      ],
-      [
-        [
-          0,
-          0
-        ],
-        [
-          0.5,
-          0.5
-        ]
+        [0, 0],
+        [0.5, 0.5]
       ]
     ],
     [
       "coverage above 1",
+      [2, 1.5, null],
       [
-        2,
-        1.5,
-        null
-      ],
-      [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "weights sum below 1",
+      [2, 1, [0.4, 0.1]],
       [
-        2,
-        1,
-        [
-          0.4,
-          0.1
-        ]
-      ],
-      [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "weights sum above 1",
+      [2, 1, [0.7, 0.6]],
       [
-        2,
-        1,
-        [
-          0.7,
-          0.6
-        ]
-      ],
-      [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ]
     ],
     [
       "weights.length not equal to num variations",
+      [4, 1, [0.4, 0.4, 0.2]],
       [
-        4,
-        1,
-        [
-          0.4,
-          0.4,
-          0.2
-        ]
-      ],
-      [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.25,
-          0.5
-        ],
-        [
-          0.5,
-          0.75
-        ],
-        [
-          0.75,
-          1
-        ]
+        [0, 0.25],
+        [0.25, 0.5],
+        [0.5, 0.75],
+        [0.75, 1]
       ]
     ],
     [
       "weights sum almost equals 1",
+      [2, 1, [0.4, 0.5999]],
       [
-        2,
-        1,
-        [
-          0.4,
-          0.5999
-        ]
-      ],
-      [
-        [
-          0,
-          0.4
-        ],
-        [
-          0.4,
-          0.9999
-        ]
+        [0, 0.4],
+        [0.4, 0.9999]
       ]
     ]
   ],
@@ -3540,56 +3066,44 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "unknownFeature"
+        "source": "unknownFeature",
+        "ruleId": ""
       }
     ],
     [
       "defaults when empty",
-      {
-        "features": {
-          "feature": {}
-        }
-      },
+      { "features": { "feature": {} } },
       "feature",
       {
         "value": null,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
       "uses defaultValue - number",
-      {
-        "features": {
-          "feature": {
-            "defaultValue": 1
-          }
-        }
-      },
+      { "features": { "feature": { "defaultValue": 1 } } },
       "feature",
       {
         "value": 1,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
       "uses custom values - string",
-      {
-        "features": {
-          "feature": {
-            "defaultValue": "yes"
-          }
-        }
-      },
+      { "features": { "feature": { "defaultValue": "yes" } } },
       "feature",
       {
         "value": "yes",
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3611,7 +3125,32 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rule with rule id",
+      {
+        "features": {
+          "feature": {
+            "defaultValue": 2,
+            "rules": [
+              {
+                "id": "a",
+                "force": 1
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": "a"
       }
     ],
     [
@@ -3633,7 +3172,8 @@
         "value": false,
         "on": false,
         "off": true,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3659,7 +3199,8 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3685,7 +3226,8 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3699,6 +3241,7 @@
             "defaultValue": 2,
             "rules": [
               {
+                "id": "a",
                 "force": 1,
                 "coverage": 0.5
               }
@@ -3711,7 +3254,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3735,7 +3279,36 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - coverage 0",
+      {
+        "attributes": {
+          "id": "d0bc0a5a"
+        },
+        "features": {
+          "8d156": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0,
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "8d156",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3752,12 +3325,7 @@
               {
                 "force": 1,
                 "condition": {
-                  "country": {
-                    "$in": [
-                      "US",
-                      "CA"
-                    ]
-                  },
+                  "country": { "$in": ["US", "CA"] },
                   "browser": "firefox"
                 }
               }
@@ -3770,7 +3338,8 @@
         "value": 1,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -3787,12 +3356,7 @@
               {
                 "force": 1,
                 "condition": {
-                  "country": {
-                    "$in": [
-                      "US",
-                      "CA"
-                    ]
-                  },
+                  "country": { "$in": ["US", "CA"] },
                   "browser": "firefox"
                 }
               }
@@ -3805,7 +3369,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3832,7 +3397,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3840,9 +3406,7 @@
       {
         "features": {
           "feature": {
-            "rules": [
-              {}
-            ]
+            "rules": [{}]
           }
         }
       },
@@ -3851,7 +3415,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -3864,11 +3429,7 @@
           "feature": {
             "rules": [
               {
-                "variations": [
-                  "a",
-                  "b",
-                  "c"
-                ]
+                "variations": ["a", "b", "c"]
               }
             ]
           }
@@ -3881,11 +3442,7 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": [
-            "a",
-            "b",
-            "c"
-          ]
+          "variations": ["a", "b", "c"]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -3899,7 +3456,8 @@
           "key": "2",
           "stickyBucketUsed": false
         },
-        "source": "experiment"
+        "source": "experiment",
+        "ruleId": ""
       }
     ],
     [
@@ -3912,11 +3470,8 @@
           "feature": {
             "rules": [
               {
-                "variations": [
-                  "a",
-                  "b",
-                  "c"
-                ]
+                "id": "id",
+                "variations": ["a", "b", "c"]
               }
             ]
           }
@@ -3929,11 +3484,7 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": [
-            "a",
-            "b",
-            "c"
-          ]
+          "variations": ["a", "b", "c"]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -3947,7 +3498,8 @@
           "key": "0",
           "stickyBucketUsed": false
         },
-        "source": "experiment"
+        "source": "experiment",
+        "ruleId": "id"
       }
     ],
     [
@@ -3960,11 +3512,7 @@
           "feature": {
             "rules": [
               {
-                "variations": [
-                  "a",
-                  "b",
-                  "c"
-                ]
+                "variations": ["a", "b", "c"]
               }
             ]
           }
@@ -3977,11 +3525,7 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": [
-            "a",
-            "b",
-            "c"
-          ]
+          "variations": ["a", "b", "c"]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -3995,7 +3539,8 @@
           "key": "1",
           "stickyBucketUsed": false
         },
-        "source": "experiment"
+        "source": "experiment",
+        "ruleId": ""
       }
     ],
     [
@@ -4016,14 +3561,8 @@
                 "name": "Test",
                 "phase": "1",
                 "ranges": [
-                  [
-                    0,
-                    0.1
-                  ],
-                  [
-                    0.1,
-                    1.0
-                  ]
+                  [0, 0.1],
+                  [0.1, 1.0]
                 ],
                 "meta": [
                   {
@@ -4039,31 +3578,15 @@
                   {
                     "attribute": "anonId",
                     "seed": "pricing",
-                    "ranges": [
-                      [
-                        0,
-                        1
-                      ]
-                    ]
+                    "ranges": [[0, 1]]
                   }
                 ],
-                "namespace": [
-                  "pricing",
-                  0,
-                  1
-                ],
+                "namespace": ["pricing", 0, 1],
                 "key": "hello",
-                "variations": [
-                  true,
-                  false
-                ],
-                "weights": [
-                  0.1,
-                  0.9
-                ],
-                "condition": {
-                  "premium": true
-                }
+                "variations": [true, false],
+                "weights": [0.1, 0.9],
+                "condition": { "premium": true },
+                "foo": "bar"
               }
             ]
           }
@@ -4078,14 +3601,8 @@
         "experiment": {
           "coverage": 0.99,
           "ranges": [
-            [
-              0,
-              0.1
-            ],
-            [
-              0.1,
-              1.0
-            ]
+            [0, 0.1],
+            [0.1, 1.0]
           ],
           "meta": [
             {
@@ -4101,12 +3618,7 @@
             {
               "attribute": "anonId",
               "seed": "pricing",
-              "ranges": [
-                [
-                  0,
-                  1
-                ]
-              ]
+              "ranges": [[0, 1]]
             }
           ],
           "name": "Test",
@@ -4114,23 +3626,11 @@
           "seed": "feature",
           "hashVersion": 2,
           "hashAttribute": "anonId",
-          "namespace": [
-            "pricing",
-            0,
-            1
-          ],
+          "namespace": ["pricing", 0, 1],
           "key": "hello",
-          "variations": [
-            true,
-            false
-          ],
-          "weights": [
-            0.1,
-            0.9
-          ],
-          "condition": {
-            "premium": true
-          }
+          "variations": [true, false],
+          "weights": [0.1, 0.9],
+          "condition": { "premium": true }
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4144,7 +3644,8 @@
           "key": "v1",
           "name": "variation 1",
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -4159,21 +3660,15 @@
             "rules": [
               {
                 "force": 1,
-                "condition": {
-                  "browser": "chrome"
-                }
+                "condition": { "browser": "chrome" }
               },
               {
                 "force": 2,
-                "condition": {
-                  "browser": "firefox"
-                }
+                "condition": { "browser": "firefox" }
               },
               {
                 "force": 3,
-                "condition": {
-                  "browser": "safari"
-                }
+                "condition": { "browser": "safari" }
               }
             ]
           }
@@ -4184,7 +3679,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -4199,21 +3695,18 @@
             "rules": [
               {
                 "force": 1,
-                "condition": {
-                  "browser": "chrome"
-                }
+                "id": "1",
+                "condition": { "browser": "chrome" }
               },
               {
+                "id": "2",
                 "force": 2,
-                "condition": {
-                  "browser": "firefox"
-                }
+                "condition": { "browser": "firefox" }
               },
               {
+                "id": "3",
                 "force": 3,
-                "condition": {
-                  "browser": "safari"
-                }
+                "condition": { "browser": "safari" }
               }
             ]
           }
@@ -4224,7 +3717,8 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": "3"
       }
     ],
     [
@@ -4239,21 +3733,15 @@
             "rules": [
               {
                 "force": 1,
-                "condition": {
-                  "browser": "chrome"
-                }
+                "condition": { "browser": "chrome" }
               },
               {
                 "force": 2,
-                "condition": {
-                  "browser": "firefox"
-                }
+                "condition": { "browser": "firefox" }
               },
               {
                 "force": 3,
-                "condition": {
-                  "browser": "safari"
-                }
+                "condition": { "browser": "safari" }
               }
             ]
           }
@@ -4264,26 +3752,20 @@
         "value": 0,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
       "skips experiment on coverage",
       {
-        "attributes": {
-          "id": "123"
-        },
+        "attributes": { "id": "123" },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
+                "variations": [0, 1, 2, 3],
                 "coverage": 0.01
               },
               {
@@ -4298,31 +3780,21 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
       "skips experiment on namespace",
       {
-        "attributes": {
-          "id": "123"
-        },
+        "attributes": { "id": "123" },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
-                "namespace": [
-                  "pricing",
-                  0,
-                  0.01
-                ]
+                "variations": [0, 1, 2, 3],
+                "namespace": ["pricing", 0, 0.01]
               },
               {
                 "force": 3
@@ -4336,24 +3808,20 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
       "handles integer hashAttribute",
       {
-        "attributes": {
-          "id": 123
-        },
+        "attributes": { "id": 123 },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1
-                ]
+                "variations": [0, 1]
               }
             ]
           }
@@ -4367,10 +3835,7 @@
         "source": "experiment",
         "experiment": {
           "key": "feature",
-          "variations": [
-            0,
-            1
-          ]
+          "variations": [0, 1]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4383,26 +3848,20 @@
           "key": "1",
           "bucket": 0.863,
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
       "skip experiment on missing hashAttribute",
       {
-        "attributes": {
-          "id": "123"
-        },
+        "attributes": { "id": "123" },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
+                "variations": [0, 1, 2, 3],
                 "hashAttribute": "company"
               },
               {
@@ -4417,15 +3876,14 @@
         "value": 3,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
       "include experiments when forced",
       {
-        "attributes": {
-          "id": "123"
-        },
+        "attributes": { "id": "123" },
         "forcedVariations": {
           "feature": 1
         },
@@ -4434,12 +3892,7 @@
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ]
+                "variations": [0, 1, 2, 3]
               },
               {
                 "force": 3
@@ -4456,12 +3909,7 @@
         "source": "experiment",
         "experiment": {
           "key": "feature",
-          "variations": [
-            0,
-            1,
-            2,
-            3
-          ]
+          "variations": [0, 1, 2, 3]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4473,7 +3921,8 @@
           "hashValue": "123",
           "key": "1",
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -4489,10 +3938,7 @@
               {
                 "force": 2,
                 "coverage": 0.01,
-                "range": [
-                  0,
-                  0.99
-                ]
+                "range": [0, 0.99]
               }
             ]
           }
@@ -4503,7 +3949,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -4519,10 +3966,7 @@
               {
                 "force": 2,
                 "hashVersion": 2,
-                "range": [
-                  0.96,
-                  0.97
-                ]
+                "range": [0.96, 0.97]
               }
             ]
           }
@@ -4533,7 +3977,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -4548,10 +3993,7 @@
             "rules": [
               {
                 "force": 2,
-                "range": [
-                  0,
-                  0.01
-                ]
+                "range": [0, 0.01]
               }
             ]
           }
@@ -4562,7 +4004,8 @@
         "value": 0,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -4580,12 +4023,7 @@
                 "filters": [
                   {
                     "seed": "seed",
-                    "ranges": [
-                      [
-                        0,
-                        0.01
-                      ]
-                    ]
+                    "ranges": [[0, 0.01]]
                   }
                 ]
               }
@@ -4598,7 +4036,8 @@
         "value": 0,
         "on": false,
         "off": true,
-        "source": "defaultValue"
+        "source": "defaultValue",
+        "ruleId": ""
       }
     ],
     [
@@ -4613,10 +4052,7 @@
             "rules": [
               {
                 "force": 2,
-                "range": [
-                  0,
-                  0.5
-                ],
+                "range": [0, 0.5],
                 "seed": "fjdslafdsa",
                 "hashVersion": 2
               }
@@ -4629,7 +4065,8 @@
         "value": 2,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -4644,20 +4081,11 @@
             "rules": [
               {
                 "key": "holdout",
-                "variations": [
-                  1,
-                  2
-                ],
+                "variations": [1, 2],
                 "hashVersion": 2,
                 "ranges": [
-                  [
-                    0,
-                    0.01
-                  ],
-                  [
-                    0.01,
-                    1.0
-                  ]
+                  [0, 0.01],
+                  [0.01, 1.0]
                 ],
                 "meta": [
                   {},
@@ -4668,20 +4096,11 @@
               },
               {
                 "key": "experiment",
-                "variations": [
-                  3,
-                  4
-                ],
+                "variations": [3, 4],
                 "hashVersion": 2,
                 "ranges": [
-                  [
-                    0,
-                    0.5
-                  ],
-                  [
-                    0.5,
-                    1.0
-                  ]
+                  [0, 0.5],
+                  [0.5, 1.0]
                 ]
               }
             ]
@@ -4697,19 +4116,10 @@
         "experiment": {
           "key": "experiment",
           "hashVersion": 2,
-          "variations": [
-            3,
-            4
-          ],
+          "variations": [3, 4],
           "ranges": [
-            [
-              0,
-              0.5
-            ],
-            [
-              0.5,
-              1.0
-            ]
+            [0, 0.5],
+            [0.5, 1.0]
           ]
         },
         "experimentResult": {
@@ -4723,7 +4133,8 @@
           "variationId": 0,
           "bucket": 0.4413,
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -4739,19 +4150,10 @@
               {
                 "key": "holdout",
                 "hashVersion": 2,
-                "variations": [
-                  1,
-                  2
-                ],
+                "variations": [1, 2],
                 "ranges": [
-                  [
-                    0,
-                    0.99
-                  ],
-                  [
-                    0.99,
-                    1.0
-                  ]
+                  [0, 0.99],
+                  [0.99, 1.0]
                 ],
                 "meta": [
                   {},
@@ -4763,19 +4165,10 @@
               {
                 "key": "experiment",
                 "hashVersion": 2,
-                "variations": [
-                  3,
-                  4
-                ],
+                "variations": [3, 4],
                 "ranges": [
-                  [
-                    0,
-                    0.5
-                  ],
-                  [
-                    0.5,
-                    1.0
-                  ]
+                  [0, 0.5],
+                  [0.5, 1.0]
                 ]
               }
             ]
@@ -4791,14 +4184,8 @@
         "experiment": {
           "hashVersion": 2,
           "ranges": [
-            [
-              0,
-              0.99
-            ],
-            [
-              0.99,
-              1.0
-            ]
+            [0, 0.99],
+            [0.99, 1.0]
           ],
           "meta": [
             {},
@@ -4807,10 +4194,7 @@
             }
           ],
           "key": "holdout",
-          "variations": [
-            1,
-            2
-          ]
+          "variations": [1, 2]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4823,7 +4207,8 @@
           "variationId": 0,
           "bucket": 0.8043,
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ],
     [
@@ -4839,20 +4224,11 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": {
-                  "country": "Canada"
-                },
+                "condition": { "country": "Canada" },
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": {
-                    "$in": [
-                      "USA",
-                      "Mexico"
-                    ]
-                  }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -4864,17 +4240,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -4886,7 +4258,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "prerequisite"
+        "source": "prerequisite",
+        "ruleId": ""
       }
     ],
     [
@@ -4905,17 +4278,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -4927,7 +4296,8 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "prerequisite"
+        "source": "prerequisite",
+        "ruleId": ""
       }
     ],
     [
@@ -4943,20 +4313,11 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": {
-                  "country": "Canada"
-                },
+                "condition": { "country": "Canada" },
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": {
-                    "$in": [
-                      "USA",
-                      "Mexico"
-                    ]
-                  }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -4968,17 +4329,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -4990,7 +4347,8 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -5006,20 +4364,11 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": {
-                  "country": "Canada"
-                },
+                "condition": { "country": "Canada" },
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": {
-                    "$in": [
-                      "USA",
-                      "Mexico"
-                    ]
-                  }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -5028,9 +4377,7 @@
             "defaultValue": 0,
             "rules": [
               {
-                "condition": {
-                  "id": "123"
-                },
+                "condition": { "id": "123" },
                 "force": 2
               }
             ]
@@ -5042,9 +4389,7 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag1",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
@@ -5053,19 +4398,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag2",
-                    "condition": {
-                      "value": {
-                        "$gt": 1
-                      }
-                    },
+                    "condition": { "value": { "$gt": 1 } },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5077,7 +4416,8 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -5096,30 +4436,17 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag2",
-                    "condition": {
-                      "value": {
-                        "$gt": 1
-                      }
-                    },
+                    "condition": { "value": { "$gt": 1 } },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "country": "Canada"
-                },
+                "condition": { "country": "Canada" },
                 "force": "red"
               },
               {
-                "condition": {
-                  "country": {
-                    "$in": [
-                      "USA",
-                      "Mexico"
-                    ]
-                  }
-                },
+                "condition": { "country": { "$in": ["USA", "Mexico"] } },
                 "force": "green"
               }
             ]
@@ -5128,9 +4455,7 @@
             "defaultValue": 0,
             "rules": [
               {
-                "condition": {
-                  "id": "123"
-                },
+                "condition": { "id": "123" },
                 "force": 2
               }
             ]
@@ -5142,17 +4467,13 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag1",
-                    "condition": {
-                      "value": "green"
-                    },
+                    "condition": { "value": "green" },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5164,7 +4485,8 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -5181,21 +4503,12 @@
             "rules": [
               {
                 "key": "experiment",
-                "variations": [
-                  0,
-                  1
-                ],
+                "variations": [0, 1],
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "ranges": [
-                  [
-                    0,
-                    0.5
-                  ],
-                  [
-                    0.5,
-                    1.0
-                  ]
+                  [0, 0.5],
+                  [0.5, 1.0]
                 ]
               }
             ]
@@ -5207,17 +4520,13 @@
                 "parentConditions": [
                   {
                     "id": "parentExperimentFlag",
-                    "condition": {
-                      "value": 1
-                    },
+                    "condition": { "value": 1 },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": {
-                  "memberType": "basic"
-                },
+                "condition": { "memberType": "basic" },
                 "force": "success"
               }
             ]
@@ -5229,7 +4538,61 @@
         "value": "success",
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Prerequisite experiment flag in target bucket, evaluate skip dependent flag if not bucketed",
+      {
+        "attributes": {
+          "id": "1234",
+          "memberType": "basic",
+          "country": "USA"
+        },
+        "features": {
+          "parentExperimentFlag": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "key": "experiment",
+                "variations": [0, 1],
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "ranges": [
+                  [0, 0.5],
+                  [0.5, 1.0]
+                ]
+              }
+            ]
+          },
+          "childFlag": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentExperimentFlag",
+                    "condition": { "value": 0 },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": { "memberType": "basic" },
+                "force": "success"
+              }
+            ]
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": null,
+        "on": false,
+        "off": true,
+        "source": "prerequisite",
+        "ruleId": ""
       }
     ],
     [
@@ -5246,9 +4609,7 @@
                 "parentConditions": [
                   {
                     "id": "flag2",
-                    "condition": {
-                      "value": true
-                    },
+                    "condition": { "value": true },
                     "gate": true
                   }
                 ]
@@ -5262,9 +4623,7 @@
                 "parentConditions": [
                   {
                     "id": "flag1",
-                    "condition": {
-                      "value": true
-                    },
+                    "condition": { "value": true },
                     "gate": true
                   }
                 ]
@@ -5278,7 +4637,73 @@
         "value": null,
         "on": false,
         "off": true,
-        "source": "cyclicPrerequisite"
+        "source": "cyclicPrerequisite",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Multiple references to same prerequisite, do not break",
+      {
+        "attributes": {
+          "id": "123",
+          "browser": "edge"
+        },
+        "features": {
+          "childFlag": {
+            "defaultValue": true,
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": { "value": { "$ne": false } },
+                    "gate": true
+                  },
+                  {
+                    "id": "parentFlag",
+                    "condition": { "value": true },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": {
+                  "browser": "safari"
+                },
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": { "value": true }
+                  }
+                ],
+                "force": "C"
+              },
+              {
+                "condition": {
+                  "browser": { "$ne": "safari" }
+                },
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": { "value": true }
+                  }
+                ],
+                "force": "T"
+              }
+            ]
+          },
+          "parentFlag": {
+            "defaultValue": true
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": "T",
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -5293,20 +4718,13 @@
             "rules": [
               {
                 "force": true,
-                "condition": {
-                  "id": {
-                    "$inGroup": "group_id"
-                  }
-                }
+                "condition": { "id": { "$inGroup": "group_id" } }
               }
             ]
           }
         },
         "savedGroups": {
-          "group_id": [
-            123,
-            456
-          ]
+          "group_id": [123, 456]
         }
       },
       "inGroup_force_rule",
@@ -5314,7 +4732,8 @@
         "value": true,
         "on": true,
         "off": false,
-        "source": "force"
+        "source": "force",
+        "ruleId": ""
       }
     ],
     [
@@ -5329,35 +4748,19 @@
             "rules": [
               {
                 "key": "experiment",
-                "condition": {
-                  "id": {
-                    "$inGroup": "group_id"
-                  }
-                },
+                "condition": { "id": { "$inGroup": "group_id" } },
                 "hashVersion": 2,
-                "variations": [
-                  1,
-                  2
-                ],
+                "variations": [1, 2],
                 "ranges": [
-                  [
-                    0,
-                    0.5
-                  ],
-                  [
-                    0.5,
-                    1.0
-                  ]
+                  [0, 0.5],
+                  [0.5, 1.0]
                 ]
               }
             ]
           }
         },
         "savedGroups": {
-          "group_id": [
-            123,
-            456
-          ]
+          "group_id": [123, 456]
         }
       },
       "inGroup_experiment_rule",
@@ -5368,24 +4771,11 @@
         "source": "experiment",
         "experiment": {
           "hashVersion": 2,
-          "condition": {
-            "id": {
-              "$inGroup": "group_id"
-            }
-          },
-          "variations": [
-            1,
-            2
-          ],
+          "condition": { "id": { "$inGroup": "group_id" } },
+          "variations": [1, 2],
           "ranges": [
-            [
-              0,
-              0.5
-            ],
-            [
-              0.5,
-              1.0
-            ]
+            [0, 0.5],
+            [0.5, 1.0]
           ],
           "key": "experiment"
         },
@@ -5400,797 +4790,336 @@
           "variationId": 0,
           "bucket": 0.1736,
           "stickyBucketUsed": false
-        }
+        },
+        "ruleId": ""
       }
     ]
   ],
   "run": [
     [
       "default weights - 1",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 2",
-      {
-        "attributes": {
-          "id": "2"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "2" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "default weights - 3",
-      {
-        "attributes": {
-          "id": "3"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "3" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "default weights - 4",
-      {
-        "attributes": {
-          "id": "4"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "4" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 5",
-      {
-        "attributes": {
-          "id": "5"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "5" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 6",
-      {
-        "attributes": {
-          "id": "6"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "6" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 7",
-      {
-        "attributes": {
-          "id": "7"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "7" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "default weights - 8",
-      {
-        "attributes": {
-          "id": "8"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "8" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "default weights - 9",
-      {
-        "attributes": {
-          "id": "9"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "9" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "uneven weights - 1",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 2",
-      {
-        "attributes": {
-          "id": "2"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "2" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 3",
-      {
-        "attributes": {
-          "id": "3"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "3" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       0,
       true,
       true
     ],
     [
       "uneven weights - 4",
-      {
-        "attributes": {
-          "id": "4"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "4" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 5",
-      {
-        "attributes": {
-          "id": "5"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "5" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 6",
-      {
-        "attributes": {
-          "id": "6"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "6" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 7",
-      {
-        "attributes": {
-          "id": "7"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "7" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       0,
       true,
       true
     ],
     [
       "uneven weights - 8",
-      {
-        "attributes": {
-          "id": "8"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "8" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "uneven weights - 9",
-      {
-        "attributes": {
-          "id": "9"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.1,
-          0.9
-        ]
-      },
+      { "attributes": { "id": "9" } },
+      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
       true,
       true
     ],
     [
       "coverage - 1",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       false,
       false
     ],
     [
       "coverage - 2",
-      {
-        "attributes": {
-          "id": "2"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "2" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       true,
       true
     ],
     [
       "coverage - 3",
-      {
-        "attributes": {
-          "id": "3"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "3" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       true,
       true
     ],
     [
       "coverage - 4",
-      {
-        "attributes": {
-          "id": "4"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "4" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       false,
       false
     ],
     [
       "coverage - 5",
-      {
-        "attributes": {
-          "id": "5"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "5" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       1,
       true,
       true
     ],
     [
       "coverage - 6",
-      {
-        "attributes": {
-          "id": "6"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "6" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       false,
       false
     ],
     [
       "coverage - 7",
-      {
-        "attributes": {
-          "id": "7"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "7" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       true,
       true
     ],
     [
       "coverage - 8",
-      {
-        "attributes": {
-          "id": "8"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "8" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       1,
       true,
       true
     ],
     [
       "coverage - 9",
-      {
-        "attributes": {
-          "id": "9"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "coverage": 0.4
-      },
+      { "attributes": { "id": "9" } },
+      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
       false,
       false
     ],
     [
       "three way test - 1",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       2,
       true,
       true
     ],
     [
       "three way test - 2",
-      {
-        "attributes": {
-          "id": "2"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "2" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       0,
       true,
       true
     ],
     [
       "three way test - 3",
-      {
-        "attributes": {
-          "id": "3"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "3" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       0,
       true,
       true
     ],
     [
       "three way test - 4",
-      {
-        "attributes": {
-          "id": "4"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "4" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       2,
       true,
       true
     ],
     [
       "three way test - 5",
-      {
-        "attributes": {
-          "id": "5"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "5" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       1,
       true,
       true
     ],
     [
       "three way test - 6",
-      {
-        "attributes": {
-          "id": "6"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "6" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       2,
       true,
       true
     ],
     [
       "three way test - 7",
-      {
-        "attributes": {
-          "id": "7"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "7" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       0,
       true,
       true
     ],
     [
       "three way test - 8",
-      {
-        "attributes": {
-          "id": "8"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "8" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       1,
       true,
       true
     ],
     [
       "three way test - 9",
-      {
-        "attributes": {
-          "id": "9"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1,
-          2
-        ]
-      },
+      { "attributes": { "id": "9" } },
+      { "key": "my-test", "variations": [0, 1, 2] },
       0,
       true,
       true
     ],
     [
       "test name - my-test",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1] },
       1,
       true,
       true
     ],
     [
       "test name - my-test-3",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test-3",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test-3", "variations": [0, 1] },
       0,
       true,
       true
     ],
     [
       "empty id",
-      {
-        "attributes": {
-          "id": ""
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": "" } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       false,
       false
     ],
     [
       "null id",
-      {
-        "attributes": {
-          "id": null
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": { "id": null } },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       false,
       false
     ],
     [
       "missing id",
-      {
-        "attributes": {}
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "attributes": {} },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       false,
       false
@@ -6198,68 +5127,31 @@
     [
       "missing attributes",
       {},
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
-      },
+      { "key": "my-test", "variations": [0, 1] },
       0,
       false,
       false
     ],
     [
       "single variation",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0
-        ]
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0] },
       0,
       false,
       false
     ],
     [
       "negative forced variation",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "force": -8
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1], "force": -8 },
       0,
       false,
       false
     ],
     [
       "high forced variation",
-      {
-        "attributes": {
-          "id": "1"
-        }
-      },
-      {
-        "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "force": 25
-      },
+      { "attributes": { "id": "1" } },
+      { "key": "my-test", "variations": [0, 1], "force": 25 },
       0,
       false,
       false
@@ -6274,10 +5166,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "condition": {
           "browser": "firefox"
         }
@@ -6296,10 +5185,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "condition": {
           "browser": "firefox"
         }
@@ -6318,10 +5204,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "hashAttribute": "companyId"
       },
       1,
@@ -6338,10 +5221,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       false,
@@ -6357,10 +5237,7 @@
       },
       {
         "key": "forced-test-qs",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -6376,10 +5253,7 @@
       {
         "key": "my-test",
         "active": true,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -6395,10 +5269,7 @@
       {
         "key": "my-test",
         "active": false,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       false,
@@ -6415,10 +5286,7 @@
       {
         "key": "my-test",
         "active": false,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -6435,10 +5303,7 @@
         "key": "my-test",
         "force": 1,
         "coverage": 0.01,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       false,
@@ -6474,19 +5339,12 @@
     [
       "Force variation from context",
       {
-        "attributes": {
-          "id": "1"
-        },
-        "forcedVariations": {
-          "my-test": 0
-        }
+        "attributes": { "id": "1" },
+        "forcedVariations": { "my-test": 0 }
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       true,
@@ -6495,17 +5353,12 @@
     [
       "Skips experiments in QA mode",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "qaMode": true
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       0,
       false,
@@ -6514,20 +5367,13 @@
     [
       "Works in QA mode if forced in context",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "qaMode": true,
-        "forcedVariations": {
-          "my-test": 1
-        }
+        "forcedVariations": { "my-test": 1 }
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -6536,17 +5382,12 @@
     [
       "Works in QA mode if forced in experiment",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "qaMode": true
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "force": 1
       },
       1,
@@ -6562,15 +5403,8 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "namespace": [
-          "namespace",
-          0.1,
-          1
-        ]
+        "variations": [0, 1],
+        "namespace": ["namespace", 0.1, 1]
       },
       1,
       true,
@@ -6585,15 +5419,8 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
-        "namespace": [
-          "namespace",
-          0,
-          0.1
-        ]
+        "variations": [0, 1],
+        "namespace": ["namespace", 0, 0.1]
       },
       0,
       false,
@@ -6608,10 +5435,7 @@
       },
       {
         "key": "no-coverage",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "coverage": 0
       },
       0,
@@ -6628,33 +5452,19 @@
       },
       {
         "key": "filtered",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [
-                0,
-                0.1
-              ],
-              [
-                0.2,
-                0.4
-              ]
+              [0, 0.1],
+              [0.2, 0.4]
             ]
           },
           {
             "seed": "seed",
             "attribute": "anonId",
-            "ranges": [
-              [
-                0.8,
-                1.0
-              ]
-            ]
+            "ranges": [[0.8, 1.0]]
           }
         ]
       },
@@ -6672,33 +5482,19 @@
       },
       {
         "key": "filtered",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [
-                0,
-                0.1
-              ],
-              [
-                0.2,
-                0.4
-              ]
+              [0, 0.1],
+              [0.2, 0.4]
             ]
           },
           {
             "seed": "seed",
             "attribute": "anonId",
-            "ranges": [
-              [
-                0.6,
-                0.8
-              ]
-            ]
+            "ranges": [[0.6, 0.8]]
           }
         ]
       },
@@ -6715,30 +5511,17 @@
       },
       {
         "key": "filtered",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [
-                0,
-                0.1
-              ],
-              [
-                0.2,
-                0.4
-              ]
+              [0, 0.1],
+              [0.2, 0.4]
             ]
           }
         ],
-        "namespace": [
-          "test",
-          0,
-          0.001
-        ]
+        "namespace": ["test", 0, 0.001]
       },
       1,
       true,
@@ -6753,25 +5536,13 @@
       },
       {
         "key": "ranges",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "ranges": [
-          [
-            0.99,
-            1.0
-          ],
-          [
-            0.0,
-            0.99
-          ]
+          [0.99, 1.0],
+          [0.0, 0.99]
         ],
         "coverage": 0.01,
-        "weights": [
-          0.99,
-          0.01
-        ]
+        "weights": [0.99, 0.01]
       },
       1,
       true,
@@ -6786,19 +5557,10 @@
       },
       {
         "key": "configs",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "ranges": [
-          [
-            0,
-            0.1
-          ],
-          [
-            0.9,
-            1.0
-          ]
+          [0, 0.1],
+          [0.9, 1.0]
         ]
       },
       0,
@@ -6816,19 +5578,10 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "ranges": [
-          [
-            0,
-            0.5
-          ],
-          [
-            0.5,
-            1.0
-          ]
+          [0, 0.5],
+          [0.5, 1.0]
         ]
       },
       1,
@@ -6846,10 +5599,7 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [
-          0,
-          1
-        ]
+        "variations": [0, 1]
       },
       1,
       true,
@@ -6866,14 +5616,8 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [
-          0,
-          1
-        ],
-        "weights": [
-          0.5,
-          0.5
-        ],
+        "variations": [0, 1],
+        "weights": [0.5, 0.5],
         "coverage": 0.99
       },
       1,
@@ -6883,9 +5627,7 @@
     [
       "Prerequisite condition passes",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "features": {
           "parentFlag": {
             "defaultValue": true
@@ -6894,10 +5636,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "parentConditions": [
           {
             "id": "parentFlag",
@@ -6914,9 +5653,7 @@
     [
       "Prerequisite condition fails",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "features": {
           "parentFlag": {
             "defaultValue": false
@@ -6925,10 +5662,7 @@
       },
       {
         "key": "my-test",
-        "variations": [
-          0,
-          1
-        ],
+        "variations": [0, 1],
         "parentConditions": [
           {
             "id": "parentFlag",
@@ -6945,29 +5679,15 @@
     [
       "SavedGroups correctly pulled from context for experiment",
       {
-        "attributes": {
-          "id": "4"
-        },
-        "savedGroups": {
-          "group_id": [
-            "4",
-            "5",
-            "6"
-          ]
-        }
+        "attributes": { "id": "4" },
+        "savedGroups": { "group_id": ["4", "5", "6"] }
       },
       {
         "key": "group-filtered-test",
         "condition": {
-          "id": {
-            "$inGroup": "group_id"
-          }
+          "id": { "$inGroup": "group_id" }
         },
-        "variations": [
-          0,
-          1,
-          2
-        ]
+        "variations": [0, 1, 2]
       },
       0,
       true,
@@ -6979,14 +5699,8 @@
       "even range, 0.2",
       0.2,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       0
     ],
@@ -6994,14 +5708,8 @@
       "even range, 0.4",
       0.4,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       0
     ],
@@ -7009,14 +5717,8 @@
       "even range, 0.6",
       0.6,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       1
     ],
@@ -7024,14 +5726,8 @@
       "even range, 0.8",
       0.8,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       1
     ],
@@ -7039,14 +5735,8 @@
       "even range, 0",
       0,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       0
     ],
@@ -7054,14 +5744,8 @@
       "even range, 0.5",
       0.5,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 1]
       ],
       1
     ],
@@ -7069,14 +5753,8 @@
       "reduced range, 0.2",
       0.2,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       0
     ],
@@ -7084,14 +5762,8 @@
       "reduced range, 0.4",
       0.4,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       -1
     ],
@@ -7099,14 +5771,8 @@
       "reduced range, 0.6",
       0.6,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       1
     ],
@@ -7114,14 +5780,8 @@
       "reduced range, 0.8",
       0.8,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       -1
     ],
@@ -7129,14 +5789,8 @@
       "reduced range, 0.25",
       0.25,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       -1
     ],
@@ -7144,14 +5798,8 @@
       "reduced range, 0.5",
       0.5,
       [
-        [
-          0,
-          0.25
-        ],
-        [
-          0.5,
-          0.75
-        ]
+        [0, 0.25],
+        [0.5, 0.75]
       ],
       1
     ],
@@ -7159,44 +5807,17 @@
       "zero range",
       0.5,
       [
-        [
-          0,
-          0.5
-        ],
-        [
-          0.5,
-          0.5
-        ],
-        [
-          0.5,
-          1
-        ]
+        [0, 0.5],
+        [0.5, 0.5],
+        [0.5, 1]
       ],
       2
     ]
   ],
   "getQueryStringOverride": [
-    [
-      "empty url",
-      "my-test",
-      "",
-      2,
-      null
-    ],
-    [
-      "no query string",
-      "my-test",
-      "http://example.com",
-      2,
-      null
-    ],
-    [
-      "empty query string",
-      "my-test",
-      "http://example.com?",
-      2,
-      null
-    ],
+    ["empty url", "my-test", "", 2, null],
+    ["no query string", "my-test", "http://example.com", 2, null],
+    ["empty query string", "my-test", "http://example.com?", 2, null],
     [
       "no query string match",
       "my-test",
@@ -7204,62 +5825,14 @@
       2,
       null
     ],
-    [
-      "invalid query string",
-      "my-test",
-      "http://example.com??&&&?#",
-      2,
-      null
-    ],
-    [
-      "simple match 0",
-      "my-test",
-      "http://example.com?my-test=0",
-      2,
-      0
-    ],
-    [
-      "simple match 1",
-      "my-test",
-      "http://example.com?my-test=1",
-      2,
-      1
-    ],
-    [
-      "negative variation",
-      "my-test",
-      "http://example.com?my-test=-1",
-      2,
-      null
-    ],
-    [
-      "float",
-      "my-test",
-      "http://example.com?my-test=2.054",
-      2,
-      null
-    ],
-    [
-      "string",
-      "my-test",
-      "http://example.com?my-test=foo",
-      2,
-      null
-    ],
-    [
-      "variation too high",
-      "my-test",
-      "http://example.com?my-test=5",
-      2,
-      null
-    ],
-    [
-      "high numVariations",
-      "my-test",
-      "http://example.com?my-test=5",
-      6,
-      5
-    ],
+    ["invalid query string", "my-test", "http://example.com??&&&?#", 2, null],
+    ["simple match 0", "my-test", "http://example.com?my-test=0", 2, 0],
+    ["simple match 1", "my-test", "http://example.com?my-test=1", 2, 1],
+    ["negative variation", "my-test", "http://example.com?my-test=-1", 2, null],
+    ["float", "my-test", "http://example.com?my-test=2.054", 2, null],
+    ["string", "my-test", "http://example.com?my-test=foo", 2, null],
+    ["variation too high", "my-test", "http://example.com?my-test=5", 2, null],
+    ["high numVariations", "my-test", "http://example.com?my-test=5", 6, 5],
     [
       "equal to numVariations",
       "my-test",
@@ -7281,215 +5854,33 @@
       2,
       1
     ],
-    [
-      "anchor",
-      "my-test",
-      "http://example.com?my-test=1#foo",
-      2,
-      1
-    ]
+    ["anchor", "my-test", "http://example.com?my-test=1#foo", 2, 1]
   ],
   "inNamespace": [
-    [
-      "user 1, namespace1, 1",
-      "1",
-      [
-        "namespace1",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 1, namespace1, 2",
-      "1",
-      [
-        "namespace1",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 1, namespace2, 1",
-      "1",
-      [
-        "namespace2",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 1, namespace2, 2",
-      "1",
-      [
-        "namespace2",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 2, namespace1, 1",
-      "2",
-      [
-        "namespace1",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 2, namespace1, 2",
-      "2",
-      [
-        "namespace1",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 2, namespace2, 1",
-      "2",
-      [
-        "namespace2",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 2, namespace2, 2",
-      "2",
-      [
-        "namespace2",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 3, namespace1, 1",
-      "3",
-      [
-        "namespace1",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 3, namespace1, 2",
-      "3",
-      [
-        "namespace1",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 3, namespace2, 1",
-      "3",
-      [
-        "namespace2",
-        0,
-        0.4
-      ],
-      true
-    ],
-    [
-      "user 3, namespace2, 2",
-      "3",
-      [
-        "namespace2",
-        0.4,
-        1
-      ],
-      false
-    ],
-    [
-      "user 4, namespace1, 1",
-      "4",
-      [
-        "namespace1",
-        0,
-        0.4
-      ],
-      false
-    ],
-    [
-      "user 4, namespace1, 2",
-      "4",
-      [
-        "namespace1",
-        0.4,
-        1
-      ],
-      true
-    ],
-    [
-      "user 4, namespace2, 1",
-      "4",
-      [
-        "namespace2",
-        0,
-        0.4
-      ],
-      true
-    ],
-    [
-      "user 4, namespace2, 2",
-      "4",
-      [
-        "namespace2",
-        0.4,
-        1
-      ],
-      false
-    ]
+    ["user 1, namespace1, 1", "1", ["namespace1", 0, 0.4], false],
+    ["user 1, namespace1, 2", "1", ["namespace1", 0.4, 1], true],
+    ["user 1, namespace2, 1", "1", ["namespace2", 0, 0.4], false],
+    ["user 1, namespace2, 2", "1", ["namespace2", 0.4, 1], true],
+    ["user 2, namespace1, 1", "2", ["namespace1", 0, 0.4], false],
+    ["user 2, namespace1, 2", "2", ["namespace1", 0.4, 1], true],
+    ["user 2, namespace2, 1", "2", ["namespace2", 0, 0.4], false],
+    ["user 2, namespace2, 2", "2", ["namespace2", 0.4, 1], true],
+    ["user 3, namespace1, 1", "3", ["namespace1", 0, 0.4], false],
+    ["user 3, namespace1, 2", "3", ["namespace1", 0.4, 1], true],
+    ["user 3, namespace2, 1", "3", ["namespace2", 0, 0.4], true],
+    ["user 3, namespace2, 2", "3", ["namespace2", 0.4, 1], false],
+    ["user 4, namespace1, 1", "4", ["namespace1", 0, 0.4], false],
+    ["user 4, namespace1, 2", "4", ["namespace1", 0.4, 1], true],
+    ["user 4, namespace2, 1", "4", ["namespace2", 0, 0.4], true],
+    ["user 4, namespace2, 2", "4", ["namespace2", 0.4, 1], false]
   ],
   "getEqualWeights": [
-    [
-      -1,
-      []
-    ],
-    [
-      0,
-      []
-    ],
-    [
-      1,
-      [
-        1
-      ]
-    ],
-    [
-      2,
-      [
-        0.5,
-        0.5
-      ]
-    ],
-    [
-      3,
-      [
-        0.33333333,
-        0.33333333,
-        0.33333333
-      ]
-    ],
-    [
-      4,
-      [
-        0.25,
-        0.25,
-        0.25,
-        0.25
-      ]
-    ]
+    [-1, []],
+    [0, []],
+    [1, [1]],
+    [2, [0.5, 0.5]],
+    [3, [0.33333333, 0.33333333, 0.33333333]],
+    [4, [0.25, 0.25, 0.25, 0.25]]
   ],
   "decrypt": [
     [
@@ -7557,20 +5948,13 @@
     [
       "use fallbackAttribute when missing hashAttribute",
       {
-        "attributes": {
-          "anonymousId": "123"
-        },
+        "attributes": { "anonymousId": "123" },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [
-                  0,
-                  1,
-                  2,
-                  3
-                ],
+                "variations": [0, 1, 2, 3],
                 "hashAttribute": "id",
                 "fallbackAttribute": "anonymousId"
               }
@@ -7578,6 +5962,7 @@
           }
         }
       },
+      [],
       "feature",
       {
         "bucket": 0.863,
@@ -7593,9 +5978,7 @@
       },
       {
         "anonymousId||123": {
-          "assignments": {
-            "feature__0": "3"
-          },
+          "assignments": { "feature__0": "3" },
           "attributeName": "anonymousId",
           "attributeValue": "123"
         }
@@ -7621,31 +6004,11 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
@@ -7653,6 +6016,7 @@
         },
         "stickyBucketAssignmentDocs": {}
       },
+      [],
       "exp1",
       {
         "bucket": 0.6468,
@@ -7668,9 +6032,7 @@
       },
       {
         "deviceId||d123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -7696,46 +6058,26 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
           }
-        },
-        "stickyBucketAssignmentDocs": {
-          "deviceId||d123": {
-            "attributeName": "deviceId",
-            "attributeValue": "d123",
-            "assignments": {
-              "feature-exp__0": "2"
-            }
-          }
         }
       },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__0": "2"
+          }
+        }
+      ],
       "exp1",
       {
         "bucket": 0.6468,
@@ -7751,9 +6093,7 @@
       },
       {
         "deviceId||d123": {
-          "assignments": {
-            "feature-exp__0": "2"
-          },
+          "assignments": { "feature-exp__0": "2" },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -7779,46 +6119,26 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
           }
-        },
-        "stickyBucketAssignmentDocs": {
-          "deviceId||d456": {
-            "attributeName": "deviceId",
-            "attributeValue": "d456",
-            "assignments": {
-              "feature-exp__0": "2"
-            }
-          }
         }
       },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d456",
+          "assignments": {
+            "feature-exp__0": "2"
+          }
+        }
+      ],
       "exp1",
       {
         "bucket": 0.6468,
@@ -7833,17 +6153,8 @@
         "variationId": 1
       },
       {
-        "deviceId||d456": {
-          "assignments": {
-            "feature-exp__0": "2"
-          },
-          "attributeName": "deviceId",
-          "attributeValue": "d456"
-        },
         "deviceId||d123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -7869,46 +6180,26 @@
                 "fallbackAttribute": "anonymousId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
           }
-        },
-        "stickyBucketAssignmentDocs": {
-          "anonymousId||ses123": {
-            "attributeName": "anonymousId",
-            "attributeValue": "ses123",
-            "assignments": {
-              "feature-exp__0": "1"
-            }
-          }
         }
       },
+      [
+        {
+          "attributeName": "anonymousId",
+          "attributeValue": "ses123",
+          "assignments": {
+            "feature-exp__0": "1"
+          }
+        }
+      ],
       "exp1",
       {
         "bucket": 0.9943,
@@ -7924,16 +6215,12 @@
       },
       {
         "anonymousId||ses123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "anonymousId",
           "attributeValue": "ses123"
         },
         "id||i123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -7959,53 +6246,33 @@
                 "fallbackAttribute": "anonymousId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
           }
-        },
-        "stickyBucketAssignmentDocs": {
-          "anonymousId||ses123": {
-            "attributeName": "anonymousId",
-            "attributeValue": "ses123",
-            "assignments": {
-              "feature-exp__0": "2"
-            }
-          },
-          "id||i123": {
-            "attributeName": "id",
-            "attributeValue": "i123",
-            "assignments": {
-              "feature-exp__0": "1"
-            }
-          }
         }
       },
+      [
+        {
+          "attributeName": "anonymousId",
+          "attributeValue": "ses123",
+          "assignments": {
+            "feature-exp__0": "2"
+          }
+        },
+        {
+          "attributeName": "id",
+          "attributeValue": "i123",
+          "assignments": {
+            "feature-exp__0": "1"
+          }
+        }
+      ],
       "exp1",
       {
         "bucket": 0.9943,
@@ -8021,16 +6288,12 @@
       },
       {
         "anonymousId||ses123": {
-          "assignments": {
-            "feature-exp__0": "2"
-          },
+          "assignments": { "feature-exp__0": "2" },
           "attributeName": "anonymousId",
           "attributeValue": "ses123"
         },
         "id||i123": {
-          "assignments": {
-            "feature-exp__0": "1"
-          },
+          "assignments": { "feature-exp__0": "1" },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -8055,46 +6318,24 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 3,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
           }
-        },
-        "stickyBucketAssignmentDocs": {
-          "id||i123": {
-            "assignments": {
-              "feature-exp__0": "1"
-            },
-            "attributeName": "id",
-            "attributeValue": "i123"
-          }
         }
       },
+      [
+        {
+          "assignments": { "feature-exp__0": "1" },
+          "attributeName": "id",
+          "attributeValue": "i123"
+        }
+      ],
       "exp1",
       {
         "bucket": 0.9943,
@@ -8139,46 +6380,24 @@
                 "hashVersion": 2,
                 "bucketVersion": 3,
                 "minBucketVersion": 3,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
           }
-        },
-        "stickyBucketAssignmentDocs": {
-          "id||i123": {
-            "assignments": {
-              "feature-exp__0": "1"
-            },
-            "attributeName": "id",
-            "attributeValue": "i123"
-          }
         }
       },
+      [
+        {
+          "assignments": { "feature-exp__0": "1" },
+          "attributeName": "id",
+          "attributeValue": "i123"
+        }
+      ],
       "exp1",
       null,
       {
@@ -8211,46 +6430,24 @@
                 "hashVersion": 2,
                 "bucketVersion": 1,
                 "disableStickyBucketing": true,
-                "condition": {
-                  "country": "USA"
-                },
-                "variations": [
-                  "control",
-                  "red",
-                  "blue"
-                ],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  },
-                  {
-                    "key": "2"
-                  }
-                ],
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
                 "coverage": 1,
-                "weights": [
-                  0.3334,
-                  0.3333,
-                  0.3333
-                ],
+                "weights": [0.3334, 0.3333, 0.3333],
                 "phase": "0"
               }
             ]
           }
-        },
-        "stickyBucketAssignmentDocs": {
-          "id||i123": {
-            "attributeName": "id",
-            "attributeValue": "i123",
-            "assignments": {
-              "feature-exp__0": "1"
-            }
-          }
         }
       },
+      [
+        {
+          "attributeName": "id",
+          "attributeValue": "i123",
+          "assignments": { "feature-exp__0": "1" }
+        }
+      ],
       "exp1",
       {
         "bucket": 0.9943,
@@ -8268,9 +6465,7 @@
         "id||i123": {
           "attributeName": "id",
           "attributeValue": "i123",
-          "assignments": {
-            "feature-exp__0": "1"
-          }
+          "assignments": { "feature-exp__0": "1" }
         }
       }
     ]
@@ -8279,9 +6474,7 @@
     [
       "redirects correctly without query strings",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "url": "http://www.example.com/home",
         "experiments": [
           {
@@ -8293,10 +6486,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -8317,9 +6507,7 @@
     [
       "redirects with query string on original url and persistQueryString enabled",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "url": "http://www.example.com/home?color=blue&food=sushi",
         "experiments": [
           {
@@ -8331,10 +6519,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -8356,9 +6541,7 @@
     [
       "merges query strings on original url & redirect url with param conflicts correctly when persistQueryString enabled",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "url": "http://www.example.com/home?color=blue&food=sushi&title=original",
         "experiments": [
           {
@@ -8370,10 +6553,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -8395,9 +6575,7 @@
     [
       "only performs a redirect for first eligible experiment when there are multiple eligible experiments",
       {
-        "attributes": {
-          "id": "1"
-        },
+        "attributes": { "id": "1" },
         "url": "http://www.example.com/home",
         "experiments": [
           {
@@ -8409,10 +6587,7 @@
                 "pattern": "http://www.example.com/"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -8429,10 +6604,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {
@@ -8449,10 +6621,7 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [
-              0.1,
-              0.9
-            ],
+            "weights": [0.1, 0.9],
             "variations": [
               {},
               {


### PR DESCRIPTION
Changes:
- Fix typo: `evaluted` -> `evaluated`
- Update `cases.json` to spec version `0.7.1`
- Fix evalCondition bug with multiple top-level logical operators
- Fix bug when coverage = 0
- Fix bug caused by not resetting the evaluation stack