### PR TITLE
Fix updating features

### DIFF
--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -320,7 +320,7 @@ class GrowthBookClient:
         self._sticky_bucket_cache_lock = False
         
         self._features_repository = (
-            EnhancedFeatureRepository(self.options.api_host, self.options.client_key, self.options.decryption_key)
+            EnhancedFeatureRepository(self.options.api_host, self.options.client_key, self.options.decryption_key, self.options.cache_ttl)
             if self.options.client_key
             else None
         )
@@ -465,6 +465,13 @@ class GrowthBookClient:
         
         # update user context with sticky bucket assignments
         user_context.sticky_bucket_assignment_docs = sticky_assignments
+
+        updated_features = await self._features_repository.load_features_async(
+                self.options.api_host, self.options.client_key, self.options.decryption_key, self.options.cache_ttl
+            )
+        if not updated_features:
+            logger.error("Failed to update features")
+            return False
 
         return EvaluationContext(
             user=user_context,


### PR DESCRIPTION
This pull request fixes a mismatch between the SDK behavior and its documentation regarding the stale-while-revalidate caching strategy.
Despite documentation stating support for stale-while-revalidate with TTL, the SDK never refreshed features after the initial load_features() call. Users always saw the initial state, even after TTL expiration.

Fixes:
Feature loading now follows the stale-while-revalidate model: returns cached features immediately and triggers a background refresh if TTL has expired.
This ensures users get up-to-date features on subsequent calls, as expected. [Link to this issue](https://github.com/growthbook/growthbook-python/issues/33)