### PR TITLE
Add missing imports

### DIFF
--- a/growthbook/__init__.py
+++ b/growthbook/__init__.py
@@ -1,2 +1,3 @@
 from .growthbook import *
+from .growthbook_client import *
 __version__ = "1.2.1"


### PR DESCRIPTION
Fixed incorrect GrowthBookClient import by properly exposing it in init.py. [Link to this issue ](https://github.com/growthbook/growthbook-python/issues/32)