### PR TITLE
Add method set features

### DIFF
--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -328,6 +328,7 @@ class GrowthBookClient:
         self._global_context = None
         self._context_lock = asyncio.Lock()
 
+
     def _track(self, experiment: Experiment, result: Result) -> None:
         """Thread-safe tracking implementation"""
         if not self.options.on_experiment_viewed:
@@ -369,6 +370,11 @@ class GrowthBookClient:
             except Exception:
                 logger.exception("Error in subscription callback")
 
+
+    async def set_features(self, features: dict) -> None:
+        await self._feature_update_callback({"features": features})
+        
+    
     async def _refresh_sticky_buckets(self, attributes: Dict[str, Any]) -> Dict[str, Any]:
         """Refresh sticky bucket assignments only if attributes have changed"""
         if not self.options.sticky_bucket_service:


### PR DESCRIPTION
Adds a set_features method to the async client, allowing features to be set manually.

This brings parity with the sync client, which already supports passing features directly — making it easier to use the async client in tests without triggering network calls. [Link to this issue ](https://github.com/growthbook/growthbook-python/issues/34)