### PR TITLE
Fix/python36 ubuntu removal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Static type checking with MyPy
         run: |
-          mypy growthbook/growthbook.py --implicit-optional
+          mypy growthbook/growthbook*.py --implicit-optional
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,10 @@ name: Build
 on: [push]
 jobs:
   build:
-    # Python 3.5 and 3.6 are not supported on ubuntu latest (22.04)
-    # Need to pin this to 20.04 instead
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
       - name: "Begin CI..."
@@ -34,12 +32,7 @@ jobs:
 
       - name: Static type checking with MyPy
         run: |
-          if [ "${{ matrix.python-version }}" = "3.6" ]; then
-            python -m pip install types-dataclasses
-            mypy growthbook/growthbook.py --implicit-optional --ignore-missing-imports
-          else
-            mypy growthbook/growthbook.py --implicit-optional
-          fi
+          mypy growthbook/growthbook.py --implicit-optional
 
       - name: Test with pytest
         run: |

--- a/growthbook/__init__.py
+++ b/growthbook/__init__.py
@@ -1,3 +1,10 @@
 from .growthbook import *
-from .growthbook_client import *
+
+from .growthbook_client import (
+    GrowthBookClient,
+    EnhancedFeatureRepository,
+    FeatureCache,
+    BackoffStrategy
+)
+
 __version__ = "1.2.1"

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -30,7 +30,7 @@ logger = logging.getLogger("growthbook.growthbook_client")
 
 class SingletonMeta(type):
     """Thread-safe implementation of Singleton pattern"""
-    _instances = {}
+    _instances: Dict[type, Any] = {}
     _lock = threading.Lock()
 
     def __call__(cls, *args, **kwargs):
@@ -109,11 +109,11 @@ class EnhancedFeatureRepository(FeatureRepository, metaclass=SingletonMeta):
         self._decryption_key = decryption_key
         self._cache_ttl = cache_ttl
         self._refresh_lock = threading.Lock()
-        self._refresh_task = None
+        self._refresh_task: Optional[asyncio.Task] = None
         self._stop_event = asyncio.Event()
         self._backoff = BackoffStrategy()
         self._feature_cache = FeatureCache()
-        self._callbacks = []
+        self._callbacks: List[Callable[[Dict[str, Any]], Awaitable[None]]] = []
         self._last_successful_refresh = None
         self._refresh_in_progress = asyncio.Lock()
 
@@ -157,13 +157,13 @@ class EnhancedFeatureRepository(FeatureRepository, metaclass=SingletonMeta):
             except Exception:
                 traceback.print_exc()
 
-    def add_callback(self, callback: Callable) -> None:
+    def add_callback(self, callback: Callable[[Dict[str, Any]], Awaitable[None]]) -> None:
         """Add callback to the list"""
         with self._refresh_lock:
             if callback not in self._callbacks:
                 self._callbacks.append(callback)
 
-    def remove_callback(self, callback: Callable) -> None:
+    def remove_callback(self, callback: Callable[[Dict[str, Any]], Awaitable[None]]) -> None:
         """Remove callback from the list"""
         with self._refresh_lock:
             if callback in self._callbacks:
@@ -181,7 +181,8 @@ class EnhancedFeatureRepository(FeatureRepository, metaclass=SingletonMeta):
                         response = await self.load_features_async(
                             self._api_host, self._client_key, self._decryption_key, self._cache_ttl
                         )
-                        await self._handle_feature_update(response)
+                        if response is not None:
+                            await self._handle_feature_update(response)
                     elif event_data['type'] == 'features':
                         await self._handle_feature_update(event_data['data'])
                 except Exception:
@@ -220,7 +221,8 @@ class EnhancedFeatureRepository(FeatureRepository, metaclass=SingletonMeta):
                                     decryption_key=self._decryption_key,
                                     ttl=self._cache_ttl
                                 )
-                                await self._handle_feature_update(response)
+                                if response is not None:
+                                    await self._handle_feature_update(response)
                                 # On success, reset backoff and use normal interval
                                 self._backoff.reset()
                                 try:
@@ -309,19 +311,24 @@ class GrowthBookClient:
         self._subscriptions_lock = threading.Lock()
 
         # Add sticky bucket cache
-        self._sticky_bucket_cache = {
+        self._sticky_bucket_cache: Dict[str, Dict[str, Any]] = {
             'attributes': {},
             'assignments': {}
         }
         self._sticky_bucket_cache_lock = False
         
         self._features_repository = (
-            EnhancedFeatureRepository(self.options.api_host, self.options.client_key, self.options.decryption_key)
+            EnhancedFeatureRepository(
+                self.options.api_host or "https://cdn.growthbook.io", 
+                self.options.client_key or "", 
+                self.options.decryption_key or "", 
+                self.options.cache_ttl
+            )
             if self.options.client_key
             else None
         )
         
-        self._global_context = None
+        self._global_context: Optional[GlobalContext] = None
         self._context_lock = asyncio.Lock()
 
     def _track(self, experiment: Experiment, result: Result) -> None:
@@ -383,6 +390,9 @@ class GrowthBookClient:
                 return assignments
             finally:
                 self._sticky_bucket_cache_lock = False
+        
+        # Fallback return for edge case where loop condition is never satisfied
+        return {}
 
     async def initialize(self) -> bool:
         """Initialize client with features and start refresh"""
@@ -393,7 +403,10 @@ class GrowthBookClient:
         try:
             # Initial feature load
             initial_features = await self._features_repository.load_features_async(
-                self.options.api_host, self.options.client_key, self.options.decryption_key, self.options.cache_ttl
+                self.options.api_host or "https://cdn.growthbook.io", 
+                self.options.client_key or "", 
+                self.options.decryption_key or "", 
+                self.options.cache_ttl
             )
             if not initial_features:
                 logger.error("Failed to load initial features")
@@ -406,7 +419,8 @@ class GrowthBookClient:
             self._features_repository.add_callback(self._feature_update_callback)
             
             # Start feature refresh
-            await self._features_repository.start_feature_refresh(self.options.refresh_strategy)
+            refresh_strategy = self.options.refresh_strategy or FeatureRefreshStrategy.STALE_WHILE_REVALIDATE
+            await self._features_repository.start_feature_refresh(refresh_strategy)
             return True
             
         except Exception as e:

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -10,11 +10,7 @@ import threading
 import traceback
 from datetime import datetime
 from growthbook import FeatureRepository
-try:
-    from contextlib import asynccontextmanager
-except ImportError:
-    # to support python 3.6
-    from async_generator import asynccontextmanager
+from contextlib import asynccontextmanager
 
 from .core import eval_feature as core_eval_feature, run_experiment
 from .common_types import (

--- a/setup.py
+++ b/setup.py
@@ -12,16 +12,12 @@ requirements = [
     'cryptography', 
     'typing_extensions', 
     'urllib3',
-    'dataclasses;python_version<"3.7"',  # Add dataclasses backport for Python 3.6
-    'async-generator;python_version<"3.7"',  # For asynccontextmanager in Python 3.6
     'aiohttp>=3.6.0',  # For async HTTP support
-    'importlib-metadata;python_version<"3.8"',  # For metadata in Python 3.6-3.7
 ]
 
 test_requirements = [
     'pytest>=3',
     'pytest-asyncio>=0.10.0',
-    'mock;python_version<"3.8"',  # Only install mock for Python < 3.8
 ]
 
 def get_version():
@@ -36,7 +32,7 @@ setup(
     name='growthbook',
     author="GrowthBook",
     author_email='hello@growthbook.io',
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     version=get_version(),  # Read version from __init__.py
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -44,7 +40,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
- Upgrade Ubuntu and drop support for Python 3.6 as Ubuntu 20.04 LTS runner is removed on 2025-04-15. 