### PR TITLE
Fix infinite recursion

### DIFF
--- a/growthbook/core.py
+++ b/growthbook/core.py
@@ -531,17 +531,24 @@ def eval_feature(
 
 def eval_prereqs(parentConditions: List[dict], evalContext: EvaluationContext) -> str:
     evaluated_features = evalContext.stack.evaluated_features.copy()
-
     for parentCondition in parentConditions:
         # Reset the stack in each iteration
         evalContext.stack.evaluated_features = evaluated_features.copy()
 
-        parentRes = eval_feature(key=parentCondition.get("id", None), evalContext=evalContext)
+        key = parentCondition.get("id")
+        if not isinstance(key, str):
+            continue 
+
+        condition = parentCondition.get("condition")
+        if not isinstance(condition, dict):
+            condition = {}
+
+        parentRes = eval_feature(key=key, evalContext=evalContext)
 
         if parentRes.source == "cyclicPrerequisite":
             return "cyclic"
 
-        if not evalCondition({'value': parentRes.value}, parentCondition.get("condition", None), evalContext.global_ctx.saved_groups):
+        if not evalCondition({'value': parentRes.value}, condition, evalContext.global_ctx.saved_groups):
             if parentCondition.get("gate", False):
                 return "gate"
             return "fail"

--- a/growthbook/growthbook.py
+++ b/growthbook/growthbook.py
@@ -776,6 +776,12 @@ class GrowthBook(object):
         if not self.sticky_bucket_identifier_attributes:
             return attributes
         
+        self._user_ctx.attributes = self._attributes
+        self._user_ctx.url = self._url
+        self._user_ctx.overrides = self._overrides
+        # set the url for every evaluation. (unlikely to change)
+        self._global_ctx.options.url = self._url
+        
         evalCtx = EvaluationContext(
             global_ctx = self._global_ctx,
             user = self._user_ctx,

--- a/growthbook/growthbook.py
+++ b/growthbook/growthbook.py
@@ -775,9 +775,14 @@ class GrowthBook(object):
 
         if not self.sticky_bucket_identifier_attributes:
             return attributes
+        
+        evalCtx = EvaluationContext(
+            global_ctx = self._global_ctx,
+            user = self._user_ctx,
+            stack = StackContext(evaluated_features=set()))
 
         for attr in self.sticky_bucket_identifier_attributes:
-            _, hash_value = _getHashValue(attr=attr, eval_context=self._get_eval_context())
+            _, hash_value = _getHashValue(attr=attr, eval_context=evalCtx)
             if hash_value:
                 attributes[attr] = hash_value
         return attributes


### PR DESCRIPTION
Fixed a circular recursion caused by _get_eval_context() being called inside _get_sticky_bucket_attributes(). This triggered repeated feature reloads during sticky bucket refresh.

The fix replaces _get_eval_context() with a direct creation of EvaluationContext, breaking the cycle while preserving sticky bucket logic.