### PR TITLE
Add gzip encoding header to features call

### DIFF
--- a/growthbook/growthbook.py
+++ b/growthbook/growthbook.py
@@ -139,7 +139,7 @@ class SSEClient:
         self.headers = {
             "Accept": "application/json; q=0.5, text/event-stream",
             "Cache-Control": "no-cache",
-            "Accept-Encoding": "gzip",
+            "Accept-Encoding": "gzip, deflate, br",
         }
 
         if headers:


### PR DESCRIPTION
- Add `gzip` encoding header to feature refresh calls for compressed response