### PR TITLE
fix: SSE encrypted features silently wipe feature cache

### DIFF
--- a/growthbook/growthbook.py
+++ b/growthbook/growthbook.py
@@ -844,7 +844,6 @@ class GrowthBook(object):
                 self.set_features(features["features"])
             if "savedGroups" in features:
                 self._saved_groups = features["savedGroups"]
-            feature_repo.save_in_cache(self._client_key, features, self._cache_ttl)
 
     def _features_event_handler(self, features):
         decoded = json.loads(features)
@@ -852,13 +851,14 @@ class GrowthBook(object):
             return None
         
         data = feature_repo.decrypt_response(decoded, self._decryption_key)
+        key = self._api_host + "::" + self._client_key
 
         if data is not None:
             if "features" in data:
                 self.set_features(data["features"])
             if "savedGroups" in data:
                 self._saved_groups = data["savedGroups"]
-            feature_repo.save_in_cache(self._client_key, features, self._cache_ttl)
+            feature_repo.save_in_cache(key, data, self._cache_ttl)
 
     def _dispatch_sse_event(self, event_data):
         event_type = event_data['type']

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -204,6 +204,14 @@ class EnhancedFeatureRepository(FeatureRepository, metaclass=SingletonMeta):
                 data = event_data.get("data", "{}")
                 if isinstance(data, str):
                     data = json.loads(data)
+
+                if self._decryption_key and isinstance(data, dict) and (
+                    "encryptedFeatures" in data or "encryptedSavedGroups" in data
+                ):
+                    logger.debug("Decrypting SSE payload...")
+                    data = self.decrypt_response(data, self._decryption_key)
+                    logger.debug(f"🟢 Decrypted. Features keys: {list(data.get('features', {}).keys())}")
+
                 await self._handle_feature_update(data)
         except Exception:
             logger.exception("Error handling SSE event")


### PR DESCRIPTION
## Problem
With SSE + encrypted features, every `features` event wipes the cache because `encryptedFeatures` is ignored and `features` key is empty {}.

## Changes
- `growthbook_client.py`: decrypt SSE payload before updating cache
- `growthbook.py`: fix wrong cache key and save decrypted data