### PR TITLE
Fix per-request memory leaks and redundant payload re-parsing

### DIFF
--- a/growthbook/core.py
+++ b/growthbook/core.py
@@ -935,10 +935,7 @@ def _generate_sticky_bucket_assignment_doc(attribute_name: str, attribute_value:
 
     new_assignments = {**existing_assignments, **assignments}
 
-    # Compare JSON strings to see if they have changed
-    existing_json = json.dumps(existing_assignments, sort_keys=True)
-    new_json = json.dumps(new_assignments, sort_keys=True)
-    changed = existing_json != new_json
+    changed = new_assignments != existing_assignments
 
     return {
         'key': key,

--- a/growthbook/growthbook.py
+++ b/growthbook/growthbook.py
@@ -10,6 +10,7 @@ import json
 import threading
 import logging
 import warnings
+import weakref
 
 from abc import ABC, abstractmethod
 from typing import Optional, Any, Set, Tuple, List, Dict, Callable
@@ -359,22 +360,43 @@ class FeatureRepository(object):
         self.cache.set(key, res, ttl)
 
     def add_feature_update_callback(self, callback: Callable[[Dict], None]) -> None:
-        """Add a callback to be notified when features are updated due to cache expiry"""
-        if callback not in self._feature_update_callbacks:
-            self._feature_update_callbacks.append(callback)
+        """Add a callback to be notified when features are updated due to cache expiry.
+
+        Bound methods are stored as weak references so that registering a
+        per-request ``GrowthBook`` instance does not pin it (and its payload)
+        in memory for the lifetime of this module-level singleton.
+        """
+        # Wrap so every entry is callable as ref() -> Optional[callback]
+        if hasattr(callback, "__self__"):
+            ref = weakref.WeakMethod(callback)
+        else:
+            _cb = callback
+            ref = lambda: _cb  # noqa: E731 — strong ref is intentional for plain functions
+        for existing in self._feature_update_callbacks:
+            if existing() == callback:
+                return
+        self._feature_update_callbacks.append(ref)
 
     def remove_feature_update_callback(self, callback: Callable[[Dict], None]) -> None:
-        """Remove a feature update callback"""
-        if callback in self._feature_update_callbacks:
-            self._feature_update_callbacks.remove(callback)
+        """Remove a feature update callback (and prune any dead weak refs)."""
+        self._feature_update_callbacks = [
+            r for r in self._feature_update_callbacks
+            if r() is not None and r() != callback
+        ]
 
     def _notify_feature_update_callbacks(self, features_data: Dict) -> None:
-        """Notify all registered callbacks about feature updates"""
-        for callback in self._feature_update_callbacks:
+        """Notify all registered callbacks about feature updates."""
+        live = []
+        for ref in self._feature_update_callbacks:
+            cb = ref()
+            if cb is None:
+                continue
+            live.append(ref)
             try:
-                callback(features_data)
+                cb(features_data)
             except Exception as e:
                 logger.warning(f"Error in feature update callback: {e}")
+        self._feature_update_callbacks = live
 
     # Loads features with an in-memory cache in front using stale-while-revalidate approach
     def load_features(
@@ -758,6 +780,10 @@ class GrowthBook(object):
         self._assigned: Dict[str, Any] = {}
         self._subscriptions: Set[Any] = set()
         self._is_updating_features = False
+        # Identity sentinel for the last raw payload we parsed; lets
+        # _ensure_fresh_features skip set_features() on a cache hit.
+        self._last_features_raw: Optional[dict] = None
+        self._last_saved_groups_raw: Optional[dict] = None
         self._event_logger: Optional[Any] = None
 
         # support plugins
@@ -825,11 +851,22 @@ class GrowthBook(object):
         response = feature_repo.load_features(
             self._api_host, self._client_key, self._decryption_key, self._cache_ttl
         )
-        if response is not None and "features" in response.keys():
-            self.set_features(response["features"])
+        if response is None:
+            return
 
-        if response is not None and "savedGroups" in response:
-            self._saved_groups = response["savedGroups"]
+        features = response.get("features")
+        saved_groups = response.get("savedGroups")
+
+        # On a cache hit feature_repo returns the same dict object, so an
+        # identity check lets _ensure_fresh_features (called per-eval) avoid
+        # rebuilding every Feature/FeatureRule when nothing changed.
+        if saved_groups is not None and saved_groups is not self._last_saved_groups_raw:
+            self._last_saved_groups_raw = saved_groups
+            self._saved_groups = saved_groups
+            self._global_ctx.saved_groups = saved_groups
+        if features is not None and features is not self._last_features_raw:
+            self._last_features_raw = features
+            self.set_features(features)
 
     async def load_features_async(self) -> None:
         if not self._client_key:
@@ -967,19 +1004,23 @@ class GrowthBook(object):
         except Exception as e:
             logger.warning(f"Error removing feature update callback: {e}")
         
-        # Clear all internal state
+        # Drop internal state. Reassign rather than .clear() so we never
+        # mutate dicts that were passed in by the caller or shared with
+        # other instances (e.g. a cached parsed-features dict).
         try:
-            self._subscriptions.clear()
-            self._tracked.clear()
-            self._assigned.clear()
+            self._subscriptions = set()
+            self._tracked = {}
+            self._assigned = {}
             self._trackingCallback = None
             self._featureUsageCallback = None
             self._event_logger = None
-            self._forcedVariations.clear()
-            self._overrides.clear()
-            self._groups.clear()
-            self._attributes.clear()
-            self._features.clear()
+            self._forcedVariations = {}
+            self._overrides = {}
+            self._groups = {}
+            self._attributes = {}
+            self._features = {}
+            self._last_features_raw = None
+            self._last_saved_groups_raw = None
             logger.debug("GrowthBook instance destroyed successfully")
         except Exception as e:
             logger.warning(f"Error clearing internal state: {e}")

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -359,9 +359,11 @@ class GrowthBookClient:
             else Options()
         )
         
-        # Thread-safe tracking state
-        self._tracked: Dict[str, bool] = {}  # Access only within async context
+        # Thread-safe tracking state. Bounded so a long-lived client serving
+        # many distinct users doesn't grow this dedup map without limit.
+        self._tracked: Dict[str, bool] = {}
         self._tracked_lock = threading.Lock()
+        self._tracked_max = 100_000
         
         # Thread-safe subscription management
         self._subscriptions: Set[Callable[[Experiment, Result], None]] = set()
@@ -412,12 +414,17 @@ class GrowthBookClient:
         )
 
         with self._tracked_lock:
-            if not self._tracked.get(key):
-                try:
-                    self.options.on_experiment_viewed(experiment, result, user_context)
-                    self._tracked[key] = True
-                except Exception:
-                    logger.exception("Error in tracking callback")
+            if key in self._tracked:
+                return
+            try:
+                self.options.on_experiment_viewed(experiment, result, user_context)
+                if len(self._tracked) >= self._tracked_max:
+                    # Dedup is best-effort; an occasional duplicate fire after
+                    # reset is acceptable, unbounded memory growth is not.
+                    self._tracked.clear()
+                self._tracked[key] = True
+            except Exception:
+                logger.exception("Error in tracking callback")
 
     def subscribe(self, callback: Callable[[Experiment, Result], None]) -> Callable[[], None]:
         """Thread-safe subscription management"""

--- a/tests/test_perf_leaks.py
+++ b/tests/test_perf_leaks.py
@@ -1,0 +1,79 @@
+"""Regression tests for memory-leak / redundant-reparse fixes."""
+import gc
+import weakref
+
+from growthbook import GrowthBook
+from growthbook.growthbook import feature_repo
+from growthbook.growthbook_client import GrowthBookClient
+from growthbook.common_types import Options, UserContext, Experiment, Result
+
+
+def test_feature_update_callback_does_not_pin_instance():
+    """Per-request GrowthBook(client_key=...) must be GC-able without destroy()."""
+    feature_repo._feature_update_callbacks = []
+    gb = GrowthBook(client_key="sdk-abc", features={"f": {"defaultValue": 1}})
+    assert len(feature_repo._feature_update_callbacks) == 1
+    inst_ref = weakref.ref(gb)
+    del gb
+    gc.collect()
+    assert inst_ref() is None, "registered callback is pinning the GrowthBook instance"
+    # Dead refs are pruned on next notify
+    feature_repo._notify_feature_update_callbacks({"features": {}})
+    assert len(feature_repo._feature_update_callbacks) == 0
+
+
+def test_feature_update_callback_dedup_and_remove():
+    feature_repo._feature_update_callbacks = []
+    calls = []
+
+    def cb(data):
+        calls.append(data)
+
+    feature_repo.add_feature_update_callback(cb)
+    feature_repo.add_feature_update_callback(cb)
+    assert len(feature_repo._feature_update_callbacks) == 1
+    feature_repo._notify_feature_update_callbacks({"features": {"x": {}}})
+    assert len(calls) == 1
+    feature_repo.remove_feature_update_callback(cb)
+    assert len(feature_repo._feature_update_callbacks) == 0
+
+
+def test_load_features_skips_reparse_on_cache_hit(mocker):
+    feature_repo.clear_cache()
+    feature_repo._feature_update_callbacks = []
+    payload = {"features": {"f": {"defaultValue": True}}, "savedGroups": {}}
+    mocker.patch.object(feature_repo, "load_features", return_value=payload)
+    gb = GrowthBook(client_key="sdk-abc")
+    spy = mocker.spy(gb, "set_features")
+    gb.load_features()
+    gb.load_features()
+    gb.load_features()
+    assert spy.call_count == 1, "identity-equal payload should not trigger re-parse"
+    assert gb.is_on("f") is True
+    gb.destroy()
+
+
+def test_destroy_does_not_mutate_caller_dicts():
+    attrs = {"id": "u1"}
+    gb = GrowthBook(features={"f": {"defaultValue": 1}}, attributes=attrs)
+    gb.destroy()
+    assert attrs == {"id": "u1"}, "destroy() must not .clear() caller-supplied dicts"
+
+
+def test_growthbook_client_tracked_is_bounded():
+    client = GrowthBookClient(Options(on_experiment_viewed=lambda e, r, u: None))
+    client._tracked_max = 8
+    exp = Experiment(key="exp", variations=[0, 1])
+    uc = UserContext(attributes={})
+    for i in range(40):
+        res = Result(
+            variationId=0,
+            inExperiment=True,
+            value=0,
+            hashUsed=True,
+            hashAttribute="id",
+            hashValue=str(i),
+            featureId="f",
+        )
+        client._track(exp, res, uc)
+    assert len(client._tracked) <= client._tracked_max


### PR DESCRIPTION
## Problem

Three resource issues in long-running / high-QPS server usage that don't surface in unit tests:

1. **Per-request callback leak** — `GrowthBook(client_key=...)` registers `self._on_feature_update` (a bound method) on the module-level `feature_repo` singleton. The bound method holds a strong reference to the instance, so a per-request usage pattern that doesn't call `destroy()` pins every instance (and its parsed feature payload) for the lifetime of the process. `_feature_update_callbacks` grows linearly and every refresh fans out to N dead instances.

2. **Per-eval re-parse** — when `client_key` is set without `streaming` or `stale_while_revalidate`, `_ensure_fresh_features()` runs on every `is_on()` / `eval_feature()` call. It calls `load_features()`, which gets a cache hit from `feature_repo` and then unconditionally calls `set_features()` — rebuilding every `Feature` / `FeatureRule` object from the same dict it parsed last time.

3. **Unbounded `_tracked` in `GrowthBookClient`** — the experiment-viewed dedup map is keyed by `(hashAttribute, hashValue, experimentKey, variationId)` and never evicts. A long-lived async client serving many distinct users grows this map without bound.

Plus two smaller items: `destroy()` calls `.clear()` on dicts the caller may have passed in (or that may be shared), and `_generate_sticky_bucket_assignment_doc` round-trips both dicts through `json.dumps(sort_keys=True)` just to compare them.

## Reproduction

```python
import gc, weakref
from growthbook import GrowthBook
from growthbook.growthbook import feature_repo

feature_repo._feature_update_callbacks = []
gb = GrowthBook(client_key="sdk-abc", features={"f": {"defaultValue": 1}})
ref = weakref.ref(gb)
del gb
gc.collect()
print("collected:", ref() is None)               # False on main, True with this PR
print("callbacks:", len(feature_repo._feature_update_callbacks))  # 1 (still holds dead ref on main)
```

For the per-eval re-parse, mock `feature_repo.load_features` to return a fixed dict and spy on `set_features` — on main it's called once per `is_on()`; with this PR it's called once total.

## Fix

- `FeatureRepository.add_feature_update_callback` wraps bound methods in `weakref.WeakMethod` (plain functions keep a strong ref). `_notify_feature_update_callbacks` and `remove_feature_update_callback` dereference and prune dead entries.
- `GrowthBook.load_features` records the identity of the last raw payload it parsed and skips `set_features()` when the cache returns the same object.
- `GrowthBookClient._tracked` is capped at 100k entries; on overflow it clears (occasional duplicate `on_experiment_viewed` is acceptable, unbounded growth is not).
- `destroy()` reassigns containers instead of `.clear()`.
- Sticky-bucket change detection uses `dict !=` directly.

## Tests

New `tests/test_perf_leaks.py` with five regression tests, including a real GC assertion that the instance is collectable after registration. `pytest tests/test_growthbook.py tests/test_perf_leaks.py` → 490 passed.

No evaluation semantics touched.
