### PR TITLE
Speed up payload parsing, fnv1a32, and version-string comparison

### DIFF
--- a/growthbook/common_types.py
+++ b/growthbook/common_types.py
@@ -235,35 +235,9 @@ class Feature(object):
         if rules is None:
             rules = []
         self.defaultValue = defaultValue
-        self.rules: List[FeatureRule] = []
-        for rule in rules:
-            if isinstance(rule, FeatureRule):
-                self.rules.append(rule)
-            else:
-                self.rules.append(FeatureRule(
-                    id=rule.get("id", None),
-                    key=rule.get("key", ""),
-                    variations=rule.get("variations", None),
-                    weights=rule.get("weights", None),
-                    coverage=rule.get("coverage", None),
-                    condition=rule.get("condition", None),
-                    namespace=rule.get("namespace", None),
-                    force=rule.get("force", None),
-                    hashAttribute=rule.get("hashAttribute", "id"),
-                    fallbackAttribute=rule.get("fallbackAttribute", None),
-                    hashVersion=rule.get("hashVersion", None),
-                    range=rule.get("range", None),
-                    ranges=rule.get("ranges", None),
-                    meta=rule.get("meta", None),
-                    filters=rule.get("filters", None),
-                    seed=rule.get("seed", None),
-                    name=rule.get("name", None),
-                    phase=rule.get("phase", None),
-                    disableStickyBucketing=rule.get("disableStickyBucketing", False),
-                    bucketVersion=rule.get("bucketVersion", None),
-                    minBucketVersion=rule.get("minBucketVersion", None),
-                    parentConditions=rule.get("parentConditions", None),
-                ))
+        self.rules: List[FeatureRule] = [
+            r if isinstance(r, FeatureRule) else FeatureRule(**r) for r in rules
+        ]
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -296,6 +270,7 @@ class FeatureRule(object):
         bucketVersion: Optional[int] = None,
         minBucketVersion: Optional[int] = None,
         parentConditions: Optional[List[Dict[str, Any]]] = None,
+        **_ignored: Any,
     ) -> None:
 
         if disableStickyBucketing:

--- a/growthbook/core.py
+++ b/growthbook/core.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import json
+from functools import lru_cache
 
 from urllib.parse import urlparse, parse_qs
 from typing import Callable, Optional, Any, Set, Tuple, List, Dict
@@ -242,6 +243,10 @@ def evalOperatorCondition(operator, attributeValue, conditionValue, savedGroups)
         return not evalConditionValue(conditionValue, attributeValue, savedGroups)
     return False
 
+_re_ver_strip = re.compile(r"(^v|\+.*$)")
+_re_ver_split = re.compile(r"[-.]")
+
+@lru_cache(maxsize=512)
 def paddedVersionString(input) -> str:
     # If input is a number, convert to a string
     if _is_numeric(input):
@@ -251,10 +256,10 @@ def paddedVersionString(input) -> str:
         input = "0"
 
     # Remove build info and leading `v` if any
-    input = re.sub(r"(^v|\+.*$)", "", input)
+    input = _re_ver_strip.sub("", input)
     # Split version into parts (both core version numbers and pre-release tags)
     # "v1.2.3-rc.1+build123" -> ["1","2","3","rc","1"]
-    parts = re.split(r"[-.]", input)
+    parts = _re_ver_split.split(input)
     # If it's SemVer without a pre-release, add `~` to the end
     # ["1","0","0"] -> ["1","0","0","~"]
     # "~" is the largest ASCII character, so this will make "1.0.0" greater than "1.0.0-beta" for example
@@ -262,7 +267,7 @@ def paddedVersionString(input) -> str:
         parts.append("~")
     # Left pad each numeric part with spaces so string comparisons will work ("9">"10", but " 9"<"10")
     # Then, join back together into a single string
-    return "-".join([v.rjust(5, " ") if re.match(r"^[0-9]+$", v) else v for v in parts])
+    return "-".join([v.rjust(5, " ") if v.isdigit() else v for v in parts])
 
 
 def isIn(conditionValue, attributeValue, insensitive: bool = False) -> bool:
@@ -376,13 +381,14 @@ def _isFilteredOut(filters: List[Filter], eval_context: EvaluationContext) -> bo
     return False
 
 
-def fnv1a32(str: str) -> int:
+def fnv1a32(s: str) -> int:
     hval = 0x811C9DC5
-    prime = 0x01000193
-    uint32_max = 2 ** 32
-    for s in str:
-        hval = hval ^ ord(s)
-        hval = (hval * prime) % uint32_max
+    if s.isascii():
+        for b in s.encode():
+            hval = ((hval ^ b) * 0x01000193) & 0xFFFFFFFF
+    else:
+        for ch in s:
+            hval = ((hval ^ ord(ch)) * 0x01000193) & 0xFFFFFFFF
     return hval
 
 def inNamespace(userId: str, namespace: Tuple[str, float, float]) -> bool:


### PR DESCRIPTION
## Problem

Profiling a server-style workload (one `GrowthBook(features=...)` per request, 200-feature payload, 30 `is_on()` calls per request, 2000 requests, Python 3.13) shows three hot spots that together account for most of the SDK's CPU time:

| | tottime | calls | note |
|---|---|---|---|
| `Feature.__init__` (`common_types.py:234`) | 1.21 s | 200 000 | 22 explicit `rule.get(...)` per rule → 4.8M `dict.get` |
| `fnv1a32` (`core.py:379`) | 0.20 s | 20 100 | per-character `ord()` loop + `% 2**32` |
| `paddedVersionString` (`core.py:245`) | 0.14 s | 7 992 | recompiles 3 regexes per call, never cached |

`Feature.__init__` alone is ~67% of per-request wall time — the same payload dict is re-converted into `Feature`/`FeatureRule` objects on every instance.

## Reproduction

```python
import time
from growthbook import GrowthBook

# build a ~200-feature payload with a mix of conditions / rollouts / experiments;
# any realistic payload from /api/features/<sdk-key> works
features = {...}
hot_keys = list(features)[:30]

t0 = time.perf_counter()
for i in range(2000):
    gb = GrowthBook(features=features, attributes={"id": f"u{i}"})
    for k in hot_keys:
        gb.is_on(k)
    gb.destroy()
print(f"{(time.perf_counter()-t0)*1000:.1f} ms")
```

Full harness with cProfile output is easy to assemble from the above; happy to drop it in `tests/` if useful.

## Fix

- **`Feature.__init__`**: replace the 22 `rule.get("field", default)` calls (whose defaults are byte-identical to `FeatureRule.__init__`'s own) with `FeatureRule(**rule)`. `FeatureRule.__init__` gains a `**_ignored` catch-all so unknown payload fields are still tolerated, matching today's behavior.
- **`fnv1a32`**: iterate `s.encode()` (bytes are already ints) and mask with `& 0xFFFFFFFF`. Non-ASCII input falls back to the original code-point loop so hash values are unchanged.
- **`paddedVersionString`**: wrap in `@lru_cache(maxsize=512)` (version strings repeat heavily across rules and requests), precompile the two regex patterns at module load, and use `str.isdigit()` instead of `re.match(r"^[0-9]+$", v)` for the per-part numeric test.

## Result

Same workload, same machine:

| | before | after | |
|---|---|---|---|
| per-request instance (2000 × 30 evals) | 1623 ms | **1036 ms** | 1.57× |
| reused instance (2000 × 30 evals) | 668 ms | **553 ms** | 1.21× |
| cProfile function calls (1000 req) | 8.05 M | **2.76 M** | −66% |

`pytest tests/test_growthbook.py` → 485 passed (all `cases.json` conformance tests, identical evaluation results). Net diff: +19 / −38.
