### PR TITLE
Followup - Speed up payload parsing, fnv1a32, and version-string comparison

### DIFF
--- a/growthbook/common_types.py
+++ b/growthbook/common_types.py
@@ -235,35 +235,9 @@ class Feature(object):
         if rules is None:
             rules = []
         self.defaultValue = defaultValue
-        self.rules: List[FeatureRule] = []
-        for rule in rules:
-            if isinstance(rule, FeatureRule):
-                self.rules.append(rule)
-            else:
-                self.rules.append(FeatureRule(
-                    id=rule.get("id", None),
-                    key=rule.get("key", ""),
-                    variations=rule.get("variations", None),
-                    weights=rule.get("weights", None),
-                    coverage=rule.get("coverage", None),
-                    condition=rule.get("condition", None),
-                    namespace=rule.get("namespace", None),
-                    force=rule.get("force", None),
-                    hashAttribute=rule.get("hashAttribute", "id"),
-                    fallbackAttribute=rule.get("fallbackAttribute", None),
-                    hashVersion=rule.get("hashVersion", None),
-                    range=rule.get("range", None),
-                    ranges=rule.get("ranges", None),
-                    meta=rule.get("meta", None),
-                    filters=rule.get("filters", None),
-                    seed=rule.get("seed", None),
-                    name=rule.get("name", None),
-                    phase=rule.get("phase", None),
-                    disableStickyBucketing=rule.get("disableStickyBucketing", False),
-                    bucketVersion=rule.get("bucketVersion", None),
-                    minBucketVersion=rule.get("minBucketVersion", None),
-                    parentConditions=rule.get("parentConditions", None),
-                ))
+        self.rules: List[FeatureRule] = [
+            r if isinstance(r, FeatureRule) else FeatureRule(**r) for r in rules
+        ]
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -296,6 +270,7 @@ class FeatureRule(object):
         bucketVersion: Optional[int] = None,
         minBucketVersion: Optional[int] = None,
         parentConditions: Optional[List[Dict[str, Any]]] = None,
+        **_ignored: Any,
     ) -> None:
 
         if disableStickyBucketing:

--- a/growthbook/core.py
+++ b/growthbook/core.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import json
+from functools import lru_cache
 
 from urllib.parse import urlparse, parse_qs
 from typing import Callable, Optional, Any, Set, Tuple, List, Dict
@@ -242,6 +243,10 @@ def evalOperatorCondition(operator, attributeValue, conditionValue, savedGroups)
         return not evalConditionValue(conditionValue, attributeValue, savedGroups)
     return False
 
+_re_ver_strip = re.compile(r"(^v|\+.*$)")
+_re_ver_split = re.compile(r"[-.]")
+
+@lru_cache(maxsize=512)
 def paddedVersionString(input) -> str:
     # If input is a number, convert to a string
     if _is_numeric(input):
@@ -251,10 +256,10 @@ def paddedVersionString(input) -> str:
         input = "0"
 
     # Remove build info and leading `v` if any
-    input = re.sub(r"(^v|\+.*$)", "", input)
+    input = _re_ver_strip.sub("", input)
     # Split version into parts (both core version numbers and pre-release tags)
     # "v1.2.3-rc.1+build123" -> ["1","2","3","rc","1"]
-    parts = re.split(r"[-.]", input)
+    parts = _re_ver_split.split(input)
     # If it's SemVer without a pre-release, add `~` to the end
     # ["1","0","0"] -> ["1","0","0","~"]
     # "~" is the largest ASCII character, so this will make "1.0.0" greater than "1.0.0-beta" for example
@@ -262,7 +267,7 @@ def paddedVersionString(input) -> str:
         parts.append("~")
     # Left pad each numeric part with spaces so string comparisons will work ("9">"10", but " 9"<"10")
     # Then, join back together into a single string
-    return "-".join([v.rjust(5, " ") if re.match(r"^[0-9]+$", v) else v for v in parts])
+    return "-".join([v.rjust(5, " ") if v.isdigit() else v for v in parts])
 
 
 def isIn(conditionValue, attributeValue, insensitive: bool = False) -> bool:
@@ -376,13 +381,14 @@ def _isFilteredOut(filters: List[Filter], eval_context: EvaluationContext) -> bo
     return False
 
 
-def fnv1a32(str: str) -> int:
+def fnv1a32(s: str) -> int:
     hval = 0x811C9DC5
-    prime = 0x01000193
-    uint32_max = 2 ** 32
-    for s in str:
-        hval = hval ^ ord(s)
-        hval = (hval * prime) % uint32_max
+    if s.isascii():
+        for b in s.encode():
+            hval = ((hval ^ b) * 0x01000193) & 0xFFFFFFFF
+    else:
+        for ch in s:
+            hval = ((hval ^ ord(ch)) * 0x01000193) & 0xFFFFFFFF
     return hval
 
 def inNamespace(userId: str, namespace: Tuple[str, float, float]) -> bool:

--- a/growthbook/core.py
+++ b/growthbook/core.py
@@ -243,10 +243,6 @@ def evalOperatorCondition(operator, attributeValue, conditionValue, savedGroups)
         return not evalConditionValue(conditionValue, attributeValue, savedGroups)
     return False
 
-_re_ver_strip = re.compile(r"(^v|\+.*$)")
-_re_ver_split = re.compile(r"[-.]")
-
-@lru_cache(maxsize=512)
 def paddedVersionString(input) -> str:
     # If input is a number, convert to a string
     if _is_numeric(input):
@@ -255,6 +251,15 @@ def paddedVersionString(input) -> str:
     if not input or not isinstance(input, str):
         input = "0"
 
+    return _paddedVersionString(input)
+
+
+_re_ver_strip = re.compile(r"(^v|\+.*$)")
+_re_ver_split = re.compile(r"[-.]")
+
+
+@lru_cache(maxsize=512)
+def _paddedVersionString(input: str) -> str:
     # Remove build info and leading `v` if any
     input = _re_ver_strip.sub("", input)
     # Split version into parts (both core version numbers and pre-release tags)

--- a/tests/test_growthbook.py
+++ b/tests/test_growthbook.py
@@ -106,6 +106,20 @@ def test_conditions(evalCondition_data):
     assert evalCondition(attributes, condition, savedGroups) == expected
 
 
+def test_version_comparison_normalizes_unhashable_values():
+    assert paddedVersionString(["1.2.3"]) == paddedVersionString("0")
+    assert paddedVersionString({"version": "1.2.3"}) == paddedVersionString("0")
+
+    assert evalCondition(
+        {"version": ["1.2.3"]},
+        {"version": {"$vgt": "1.0.0"}},
+    ) is False
+    assert evalCondition(
+        {"version": "1.0.0"},
+        {"version": {"$vgt": {"version": "0.9.0"}}},
+    ) is True
+
+
 def test_decrypt(decrypt_data):
     _, encrypted, key, expected = decrypt_data
     try:


### PR DESCRIPTION
## Summary

Pulls in the performance changes from external PR #112 and adds a follow-up fix for a version comparison cache regression.

PR #112 put `@lru_cache` directly on `paddedVersionString`, but `lru_cache` hashes the raw arguments before the function body runs. That meant unhashable non-string inputs like lists/dicts raised `TypeError` before the existing normalization logic could convert them to `"0"`.

This keeps `paddedVersionString` as the public normalizer and delegates to a private cached helper only after the input is guaranteed to be a string.

## Verification

- Verified `fnv1a32` output compatibility against the previous implementation across ASCII, non-ASCII, null-byte, emoji, and surrogate inputs; sampled `fnv1a32` and `gbhash` outputs matched exactly.
- `python3 -m pytest tests/test_growthbook.py::test_version_comparison_normalizes_unhashable_values`
- `python3 -m pytest tests/test_growthbook.py tests/test_dict_subclass.py tests/test_growthbook_client.py tests/test_etag.py tests/test_plugins.py`

Full suite result:

`664 passed in 37.35s`
