### PR TITLE
fix: correct sticky bucket hash attribute resolution

### DIFF
--- a/growthbook/core.py
+++ b/growthbook/core.py
@@ -316,7 +316,7 @@ def _getOrigHashValue(
     fallbackAttr: Optional[str] = None
 ) -> Tuple[str, str]:
     # attr = attr or "id" -- Fix for the flaky behavior of sticky bucket assignment
-    actual_attr: str = attr if attr is not None else ""
+    actual_attr: str = attr if attr is not None else "id"
     val = ""
 
     if actual_attr in eval_context.user.attributes:
@@ -327,7 +327,7 @@ def _getOrigHashValue(
         if fallbackAttr in eval_context.user.attributes:
             val = "" if eval_context.user.attributes[fallbackAttr] is None else eval_context.user.attributes[fallbackAttr]
 
-        if not val or val != "":
+        if val:
             actual_attr = fallbackAttr
 
     return (actual_attr, val)
@@ -635,14 +635,14 @@ def _get_sticky_bucket_assignments(evalContext: EvaluationContext,
     merged: Dict[str, str] = {}
 
     # Search for docs stored for attribute(id)
-    _, hashValue = _getHashValue(attr=attr, eval_context=evalContext)
-    key = f"{attr}||{hashValue}"
+    resolved_attr, hashValue = _getHashValue(attr=attr, eval_context=evalContext)
+    key = f"{resolved_attr}||{hashValue}"
     if key in evalContext.user.sticky_bucket_assignment_docs:
         merged = evalContext.user.sticky_bucket_assignment_docs[key].get("assignments", {})
 
     # Search for docs stored for fallback attribute
     if fallback:
-        _, hashValue = _getHashValue(fallbackAttr=fallback, eval_context=evalContext)
+        _, hashValue = _getHashValue(attr=fallback, eval_context=evalContext)
         key = f"{fallback}||{hashValue}"
         if key in evalContext.user.sticky_bucket_assignment_docs:
             # Merge the fallback assignments, but don't overwrite existing ones


### PR DESCRIPTION
## Problem

Three bugs in sticky bucket hash attribute resolution in `core.py`:

1. **Wrong default attribute** - when `attr=None`, the code fell back to `""` instead of `"id"`, diverging from the TypeScript reference implementation.

2. **Always-true condition** - `if not val or val != "":` is logically always true, so `actual_attr` was set to `fallbackAttr` even when the fallback attribute had no value in user attributes.

3. **Raw `attr` used in doc key** — `_get_sticky_bucket_assignments` discarded the resolved attribute name from `_getHashValue` and used the raw (possibly `None`) `attr` parameter to build the doc key, producing keys like `"None||user123"` instead of `"id||user123"`.
 
## Fix
- `_getOrigHashValue`: use `"id"` as default when `attr is None`;
- `_getOrigHashValue`: replace `if not val or val != "":` with `if val:` (matches Kotlin's `hashValue.isNotEmpty()` and TypeScript behavior);
- `_get_sticky_bucket_assig'nments`: use `resolved_attr` returned by `_getHashValue` instead of raw `attr` for doc key construction.
