### PR TITLE
Async sticky bucket service support for GrowthBookClient

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Static type checking with MyPy
         run: |
-          mypy growthbook/growthbook*.py --implicit-optional
+          mypy growthbook/growthbook*.py tests/typing_probe.py --implicit-optional
 
       - name: Test with pytest
         run: |

--- a/growthbook/__init__.py
+++ b/growthbook/__init__.py
@@ -1,5 +1,7 @@
 from .growthbook import *
 
+from .common_types import AbstractAsyncStickyBucketService
+
 from .growthbook_client import (
     GrowthBookClient,
     EnhancedFeatureRepository,

--- a/growthbook/common_types.py
+++ b/growthbook/common_types.py
@@ -378,8 +378,35 @@ class AbstractStickyBucketService(ABC):
                 docs[self.get_key(attributeName, attributeValue)] = doc
         return docs
 
+
+class AbstractAsyncStickyBucketService(ABC):
+    """Async twin of AbstractStickyBucketService for network-backed stores
+    (Redis, DynamoDB, ...). Only usable with the async GrowthBookClient;
+    the sync GrowthBook class rejects it at construction."""
+
+    @abstractmethod
+    async def get_assignments(self, attributeName: str, attributeValue: str) -> Optional[Dict]:
+        pass
+
+    @abstractmethod
+    async def save_assignments(self, doc: Dict) -> None:
+        pass
+
+    def get_key(self, attributeName: str, attributeValue: str) -> str:
+        return f"{attributeName}||{attributeValue}"
+
+    # By default, just loop through all attributes and call get_assignments
+    # Override this method in subclasses to perform a multi-query instead
+    async def get_all_assignments(self, attributes: Dict[str, str]) -> Dict[str, Dict]:
+        docs = {}
+        for attributeName, attributeValue in attributes.items():
+            doc = await self.get_assignments(attributeName, attributeValue)
+            if doc:
+                docs[self.get_key(attributeName, attributeValue)] = doc
+        return docs
+
 @dataclass
-class StackContext: 
+class StackContext:
     id: Optional[str] = None
     evaluated_features: Set[str] = field(default_factory=set)
 
@@ -418,7 +445,7 @@ class Options:
     enable_dev_mode: bool = False
     # forced_variations: Dict[str, Any] = field(default_factory=dict)
     refresh_strategy: Optional[FeatureRefreshStrategy] = FeatureRefreshStrategy.STALE_WHILE_REVALIDATE
-    sticky_bucket_service: Optional[AbstractStickyBucketService] = None
+    sticky_bucket_service: Optional[Union[AbstractStickyBucketService, AbstractAsyncStickyBucketService]] = None
     sticky_bucket_identifier_attributes: Optional[List[str]] = None
     on_experiment_viewed: Optional[Callable[[Experiment, Result, Optional[UserContext]], None]] = None
     on_feature_usage: Optional[Callable[[str, 'FeatureResult', UserContext], None]] = None

--- a/growthbook/common_types.py
+++ b/growthbook/common_types.py
@@ -469,6 +469,10 @@ class EvaluationContext:
     user: UserContext
     global_ctx: GlobalContext
     stack: StackContext
+    # When set, core calls this instead of sticky_bucket_service.save_assignments
+    # directly, letting the async client schedule persistence off the event loop.
+    # None (the default) preserves the sync client's direct-call behavior.
+    save_sticky_bucket_doc: Optional[Callable[[Dict], None]] = None
 
 
 # ---------------------------------------------------------------------------

--- a/growthbook/common_types.py
+++ b/growthbook/common_types.py
@@ -9,7 +9,7 @@ else:
     from typing_extensions import TypedDict
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Union, Set, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Union, Set, Tuple
 from enum import Enum
 from abc import ABC, abstractmethod
 from urllib.parse import urlparse as _urlparse
@@ -447,8 +447,11 @@ class Options:
     refresh_strategy: Optional[FeatureRefreshStrategy] = FeatureRefreshStrategy.STALE_WHILE_REVALIDATE
     sticky_bucket_service: Optional[Union[AbstractStickyBucketService, AbstractAsyncStickyBucketService]] = None
     sticky_bucket_identifier_attributes: Optional[List[str]] = None
-    on_experiment_viewed: Optional[Callable[[Experiment, Result, Optional[UserContext]], None]] = None
-    on_feature_usage: Optional[Callable[[str, 'FeatureResult', UserContext], None]] = None
+    # Callbacks may be sync (return None) or async (return an awaitable).
+    # The async GrowthBookClient schedules returned awaitables on the loop;
+    # the sync GrowthBook class supports sync callbacks only.
+    on_experiment_viewed: Optional[Callable[[Experiment, Result, Optional[UserContext]], Union[None, Awaitable[None]]]] = None
+    on_feature_usage: Optional[Callable[[str, 'FeatureResult', UserContext], Union[None, Awaitable[None]]]] = None
     tracking_plugins: Optional[List[Any]] = None
     http_connect_timeout: Optional[int] = None
     http_read_timeout: Optional[int] = None

--- a/growthbook/core.py
+++ b/growthbook/core.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import math
 import re
@@ -1018,7 +1019,21 @@ def run_experiment(experiment: Experiment,
             if not evalContext.user.sticky_bucket_assignment_docs:
                 evalContext.user.sticky_bucket_assignment_docs = {}
             evalContext.user.sticky_bucket_assignment_docs[data.get('key')] = doc
-            evalContext.global_ctx.options.sticky_bucket_service.save_assignments(doc)
+            if evalContext.save_sticky_bucket_doc:
+                # Client-provided persistence hook (the async client schedules
+                # the write off the event loop, fire-and-forget).
+                evalContext.save_sticky_bucket_doc(doc)
+            else:
+                result_ = evalContext.global_ctx.options.sticky_bucket_service.save_assignments(doc)
+                if inspect.iscoroutine(result_):
+                    # Async service without client wiring: never awaited here
+                    # (this code is synchronous). Close it to avoid a
+                    # RuntimeWarning and surface the misconfiguration.
+                    result_.close()
+                    logger.error(
+                        "Async sticky bucket service requires GrowthBookClient; "
+                        "assignment doc was not persisted"
+                    )
 
     # 14. Fire the tracking callback if set
     if tracking_cb:

--- a/growthbook/core.py
+++ b/growthbook/core.py
@@ -1016,8 +1016,9 @@ def run_experiment(experiment: Experiment,
         )
         doc = data.get("doc", None)
         if doc and data.get('changed', False):
-            if not evalContext.user.sticky_bucket_assignment_docs:
-                evalContext.user.sticky_bucket_assignment_docs = {}
+            # Mutate in place, never replace: the dict may be shared with the
+            # client's sticky bucket cache, and subsequent evals must see this
+            # assignment (read-your-writes while persistence is async).
             evalContext.user.sticky_bucket_assignment_docs[data.get('key')] = doc
             if evalContext.save_sticky_bucket_doc:
                 # Client-provided persistence hook (the async client schedules

--- a/growthbook/growthbook.py
+++ b/growthbook/growthbook.py
@@ -25,6 +25,7 @@ from .common_types import (
     StackContext,
     UserContext,
     AbstractStickyBucketService,
+    AbstractAsyncStickyBucketService,
     FeatureRule,
     build_remote_eval_payload,
     features_from_dict,
@@ -867,6 +868,13 @@ class GrowthBook(object):
     ):
         self._remoteEval = remoteEval
         self._cacheKeyAttributes = cacheKeyAttributes
+
+        if isinstance(sticky_bucket_service, AbstractAsyncStickyBucketService):
+            raise ValueError(
+                "AbstractAsyncStickyBucketService is not supported by the synchronous "
+                "GrowthBook class. Use GrowthBookClient, or provide an "
+                "AbstractStickyBucketService implementation."
+            )
 
         if remoteEval:
             validate_remote_eval_options(

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import inspect
 import json
 from dataclasses import dataclass, field
 import random
@@ -614,7 +615,7 @@ class GrowthBookClient:
         self._tracked_lock = threading.Lock()
         
         # Thread-safe subscription management
-        self._subscriptions: Set[Callable[[Experiment, Result], None]] = set()
+        self._subscriptions: Set[Callable[[Experiment, Result], Union[None, Awaitable[None]]]] = set()
         self._subscriptions_lock = threading.Lock()
 
         # Add sticky bucket cache
@@ -683,20 +684,21 @@ class GrowthBookClient:
     def _run_user_callback(self, callback: Callable, args: tuple, what: str) -> None:
         """Invoke a user callback that may be sync or async.
 
-        Called from synchronous eval paths, so a returned coroutine cannot be
+        Called from synchronous eval paths, so a returned awaitable cannot be
         awaited here; it is scheduled fire-and-forget on the running loop
         (drained in close()). Sync exceptions propagate to the caller's
         existing try/except."""
         result = callback(*args)
-        if asyncio.iscoroutine(result):
+        if inspect.isawaitable(result):
             try:
-                loop = asyncio.get_running_loop()
+                asyncio.get_running_loop()
             except RuntimeError:
-                result.close()
+                if asyncio.iscoroutine(result):
+                    result.close()
                 logger.error("Async %s callback requires a running event loop; dropped", what)
                 return
             self._spawn_tracked(
-                loop.create_task(result),
+                asyncio.ensure_future(result),
                 self._callback_tasks,
                 f"Error in {what} callback",
             )
@@ -726,7 +728,7 @@ class GrowthBookClient:
                 except Exception:
                     logger.exception("Error in tracking callback")
 
-    def subscribe(self, callback: Callable[[Experiment, Result], None]) -> Callable[[], None]:
+    def subscribe(self, callback: Callable[[Experiment, Result], Union[None, Awaitable[None]]]) -> Callable[[], None]:
         """Thread-safe subscription management"""
         with self._subscriptions_lock:
             self._subscriptions.add(callback)

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -518,8 +518,14 @@ class EnhancedFeatureRepository(FeatureRepository, metaclass=SingletonMeta):
         """Clean shutdown of refresh tasks"""
         self._stop_event.set()
         # Ensure any SSE background thread is stopped as well.
+        # stopAutoRefresh blocks joining a thread (up to `timeout` seconds),
+        # so run it in the executor to keep the event loop free — same as the
+        # SSE lifecycle teardown above.
         try:
-            self.stopAutoRefresh(timeout=10)
+            await asyncio.get_running_loop().run_in_executor(
+                None,
+                lambda: self.stopAutoRefresh(timeout=10)
+            )
         except Exception:
             # Best-effort cleanup; task cancellation below will proceed.
             logger.exception("Error stopping SSE auto-refresh")

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -25,6 +25,7 @@ from .common_types import (
     StackContext,
     FeatureResult,
     FeatureRefreshStrategy,
+    AbstractAsyncStickyBucketService,
     Experiment,
     build_remote_eval_payload,
     features_from_dict,
@@ -615,7 +616,7 @@ class GrowthBookClient:
             'attributes': {},
             'assignments': {}
         }
-        self._sticky_bucket_cache_lock = False
+        self._sticky_bucket_lock = asyncio.Lock()
         
         # Plugin support
         self._tracking_plugins: List[Any] = self.options.tracking_plugins or []
@@ -728,26 +729,31 @@ class GrowthBookClient:
         
     
     async def _refresh_sticky_buckets(self, attributes: Dict[str, Any]) -> Dict[str, Any]:
-        """Refresh sticky bucket assignments only if attributes have changed"""
-        if not self.options.sticky_bucket_service:
+        """Refresh sticky bucket assignments only if attributes have changed.
+
+        Never blocks the event loop: async services are awaited natively, sync
+        services are offloaded to the default executor. The lock also coalesces
+        concurrent refreshes for identical attributes — waiters hit the cache
+        check after the first fetch completes.
+        """
+        service = self.options.sticky_bucket_service
+        if not service:
             return {}
 
-        # Use compare-and-swap pattern
-        while not self._sticky_bucket_cache_lock:
+        async with self._sticky_bucket_lock:
             if attributes == self._sticky_bucket_cache['attributes']:
                 return self._sticky_bucket_cache['assignments']
-            
-            self._sticky_bucket_cache_lock = True
-            try:
-                assignments = self.options.sticky_bucket_service.get_all_assignments(attributes)
-                self._sticky_bucket_cache['attributes'] = attributes.copy()
-                self._sticky_bucket_cache['assignments'] = assignments
-                return assignments
-            finally:
-                self._sticky_bucket_cache_lock = False
-        
-        # Fallback return for edge case where loop condition is never satisfied
-        return {}
+
+            if isinstance(service, AbstractAsyncStickyBucketService):
+                assignments = await service.get_all_assignments(attributes)
+            else:
+                loop = asyncio.get_running_loop()
+                assignments = await loop.run_in_executor(
+                    None, service.get_all_assignments, attributes
+                )
+            self._sticky_bucket_cache['attributes'] = attributes.copy()
+            self._sticky_bucket_cache['assignments'] = assignments
+            return assignments
 
     async def initialize(self) -> bool:
         """Initialize client with features and start refresh"""
@@ -884,7 +890,11 @@ class GrowthBookClient:
         # Get sticky bucket assignments if needed
         sticky_assignments = await self._refresh_sticky_buckets(user_context.attributes)
 
-        # update user context with sticky bucket assignments
+        # Intentionally the SHARED cached dict, not a copy: core mutates it in
+        # place when an experiment assigns a new sticky bucket, which is what
+        # gives read-your-writes semantics while persistence happens
+        # asynchronously (same mechanism as the JS SDK's
+        # stickyBucketAssignmentDocs).
         user_context.sticky_bucket_assignment_docs = sticky_assignments
 
         return EvaluationContext(

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -627,6 +627,9 @@ class GrowthBookClient:
         # bare create_task results are only weakly held by the loop and can be
         # garbage-collected mid-write. Drained in close()/flush.
         self._sticky_save_tasks: Set["asyncio.Future[Any]"] = set()
+        # Strong refs to scheduled async user callbacks (tracking, feature
+        # usage, subscriptions). Drained in close().
+        self._callback_tasks: Set["asyncio.Future[Any]"] = set()
         
         # Plugin support
         self._tracking_plugins: List[Any] = self.options.tracking_plugins or []
@@ -654,6 +657,39 @@ class GrowthBookClient:
         self._initialize_plugins()
 
 
+    def _spawn_tracked(self, fut: "asyncio.Future[Any]", task_set: Set["asyncio.Future[Any]"], error_msg: str) -> None:
+        """Keep a strong ref to a fire-and-forget future until it completes;
+        log (never raise) its exception."""
+        task_set.add(fut)
+
+        def _done(f: "asyncio.Future[Any]") -> None:
+            task_set.discard(f)
+            if not f.cancelled() and f.exception():
+                logger.error(error_msg, exc_info=f.exception())
+
+        fut.add_done_callback(_done)
+
+    def _run_user_callback(self, callback: Callable, args: tuple, what: str) -> None:
+        """Invoke a user callback that may be sync or async.
+
+        Called from synchronous eval paths, so a returned coroutine cannot be
+        awaited here; it is scheduled fire-and-forget on the running loop
+        (drained in close()). Sync exceptions propagate to the caller's
+        existing try/except."""
+        result = callback(*args)
+        if asyncio.iscoroutine(result):
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                result.close()
+                logger.error("Async %s callback requires a running event loop; dropped", what)
+                return
+            self._spawn_tracked(
+                loop.create_task(result),
+                self._callback_tasks,
+                f"Error in {what} callback",
+            )
+
     def _track(self, experiment: Experiment, result: Result, user_context: UserContext) -> None:
         """Thread-safe tracking implementation"""
         if not self.options.on_experiment_viewed:
@@ -670,7 +706,11 @@ class GrowthBookClient:
         with self._tracked_lock:
             if not self._tracked.get(key):
                 try:
-                    self.options.on_experiment_viewed(experiment, result, user_context)
+                    self._run_user_callback(
+                        self.options.on_experiment_viewed,
+                        (experiment, result, user_context),
+                        "tracking",
+                    )
                     self._tracked[key] = True
                 except Exception:
                     logger.exception("Error in tracking callback")
@@ -691,7 +731,7 @@ class GrowthBookClient:
 
         for callback in subscriptions:
             try:
-                callback(experiment, result)
+                self._run_user_callback(callback, (experiment, result), "subscription")
             except Exception:
                 logger.exception("Error in subscription callback")
 
@@ -795,13 +835,7 @@ class GrowthBookClient:
             fut: "asyncio.Future[Any]" = loop.create_task(service.save_assignments(doc))
         else:
             fut = loop.run_in_executor(None, service.save_assignments, doc)
-        self._sticky_save_tasks.add(fut)
-        fut.add_done_callback(self._on_sticky_save_done)
-
-    def _on_sticky_save_done(self, fut: "asyncio.Future[Any]") -> None:
-        self._sticky_save_tasks.discard(fut)
-        if not fut.cancelled() and fut.exception():
-            logger.error("Sticky bucket save failed", exc_info=fut.exception())
+        self._spawn_tracked(fut, self._sticky_save_tasks, "Sticky bucket save failed")
 
     async def flush_sticky_bucket_saves(self) -> None:
         """Wait for all in-flight sticky bucket saves to complete.
@@ -992,7 +1026,11 @@ class GrowthBookClient:
             # Call feature usage callback if provided
             if self.options.on_feature_usage:
                 try:
-                    self.options.on_feature_usage(key, result, user_context)
+                    self._run_user_callback(
+                        self.options.on_feature_usage,
+                        (key, result, user_context),
+                        "feature usage",
+                    )
                 except Exception:
                     logger.exception("Error in feature usage callback")
             return result
@@ -1029,6 +1067,11 @@ class GrowthBookClient:
         # Let in-flight sticky bucket writes finish (sub-ms typically);
         # cancelling them would lose assignments.
         await self.flush_sticky_bucket_saves()
+
+        # Drain any scheduled async user callbacks (tracking, feature usage,
+        # subscriptions); failures are logged by their done-callbacks.
+        while self._callback_tasks:
+            await asyncio.gather(*list(self._callback_tasks), return_exceptions=True)
 
         if self._features_repository:
             await self._features_repository.stop_refresh()

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -999,41 +999,17 @@ class GrowthBookClient:
 
     async def is_on(self, key: str, user_context: UserContext) -> bool:
         """Check if a feature is enabled with proper async context management"""
-        async with self._eval_lock():
-            context = await self.create_evaluation_context(user_context)
-            result = core_eval_feature(key=key, evalContext=context, tracking_cb=self._track)
-            # Call feature usage callback if provided
-            if self.options.on_feature_usage:
-                try:
-                    self.options.on_feature_usage(key, result, user_context)
-                except Exception:
-                    logger.exception("Error in feature usage callback")
-            return result.on
+        result = await self.eval_feature(key, user_context)
+        return result.on
 
     async def is_off(self, key: str, user_context: UserContext) -> bool:
         """Check if a feature is set to off with proper async context management"""
-        async with self._eval_lock():
-            context = await self.create_evaluation_context(user_context)
-            result = core_eval_feature(key=key, evalContext=context, tracking_cb=self._track)
-            # Call feature usage callback if provided
-            if self.options.on_feature_usage:
-                try:
-                    self.options.on_feature_usage(key, result, user_context)
-                except Exception:
-                    logger.exception("Error in feature usage callback")
-            return result.off
+        result = await self.eval_feature(key, user_context)
+        return result.off
 
     async def get_feature_value(self, key: str, fallback: Any, user_context: UserContext) -> Any:
-        async with self._eval_lock():
-            context = await self.create_evaluation_context(user_context)
-            result = core_eval_feature(key=key, evalContext=context, tracking_cb=self._track)
-            # Call feature usage callback if provided
-            if self.options.on_feature_usage:
-                try:
-                    self.options.on_feature_usage(key, result, user_context)
-                except Exception:
-                    logger.exception("Error in feature usage callback")
-            return result.value if result.value is not None else fallback
+        result = await self.eval_feature(key, user_context)
+        return result.value if result.value is not None else fallback
 
     async def run(self, experiment: Experiment, user_context: UserContext) -> Result:
         """Run experiment with tracking"""

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -617,6 +617,10 @@ class GrowthBookClient:
             'assignments': {}
         }
         self._sticky_bucket_lock = asyncio.Lock()
+        # Strong refs to in-flight fire-and-forget save_assignments futures;
+        # bare create_task results are only weakly held by the loop and can be
+        # garbage-collected mid-write. Drained in close()/flush.
+        self._sticky_save_tasks: Set["asyncio.Future[Any]"] = set()
         
         # Plugin support
         self._tracking_plugins: List[Any] = self.options.tracking_plugins or []
@@ -754,6 +758,54 @@ class GrowthBookClient:
             self._sticky_bucket_cache['attributes'] = attributes.copy()
             self._sticky_bucket_cache['assignments'] = assignments
             return assignments
+
+    def _schedule_sticky_bucket_save(self, doc: Dict) -> None:
+        """Fire-and-forget persistence of a sticky bucket assignment doc,
+        mirroring the JS SDK: the in-memory doc is already updated
+        synchronously by core (read-your-writes), so the service write can
+        complete in the background without blocking the event loop.
+
+        Called synchronously from core's run_experiment via
+        EvaluationContext.save_sticky_bucket_doc.
+        """
+        service = self.options.sticky_bucket_service
+        if not service:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop (hand-rolled context outside the public API):
+            # persist inline if the service is sync, otherwise drop with a log.
+            if isinstance(service, AbstractAsyncStickyBucketService):
+                logger.error(
+                    "Cannot persist sticky bucket doc: async service but no "
+                    "running event loop"
+                )
+            else:
+                service.save_assignments(doc)
+            return
+
+        if isinstance(service, AbstractAsyncStickyBucketService):
+            fut: "asyncio.Future[Any]" = loop.create_task(service.save_assignments(doc))
+        else:
+            fut = loop.run_in_executor(None, service.save_assignments, doc)
+        self._sticky_save_tasks.add(fut)
+        fut.add_done_callback(self._on_sticky_save_done)
+
+    def _on_sticky_save_done(self, fut: "asyncio.Future[Any]") -> None:
+        self._sticky_save_tasks.discard(fut)
+        if not fut.cancelled() and fut.exception():
+            logger.error("Sticky bucket save failed", exc_info=fut.exception())
+
+    async def flush_sticky_bucket_saves(self) -> None:
+        """Wait for all in-flight sticky bucket saves to complete.
+
+        Useful in short-lived environments (e.g. serverless) where the event
+        loop may be torn down before background writes finish. close() calls
+        this automatically. Failures are logged, never raised.
+        """
+        while self._sticky_save_tasks:
+            await asyncio.gather(*list(self._sticky_save_tasks), return_exceptions=True)
 
     async def initialize(self) -> bool:
         """Initialize client with features and start refresh"""
@@ -900,7 +952,11 @@ class GrowthBookClient:
         return EvaluationContext(
             user=user_context,
             global_ctx=self._global_context,
-            stack=StackContext(evaluated_features=set())
+            stack=StackContext(evaluated_features=set()),
+            save_sticky_bucket_doc=(
+                self._schedule_sticky_bucket_save
+                if self.options.sticky_bucket_service else None
+            ),
         )
 
     @asynccontextmanager
@@ -988,6 +1044,10 @@ class GrowthBookClient:
         
     async def close(self) -> None:
         """Clean shutdown with proper cleanup"""
+        # Let in-flight sticky bucket writes finish (sub-ms typically);
+        # cancelling them would lose assignments.
+        await self.flush_sticky_bucket_saves()
+
         if self._features_repository:
             await self._features_repository.stop_refresh()
 

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -623,10 +623,21 @@ class GrowthBookClient:
             'assignments': {}
         }
         self._sticky_bucket_lock = asyncio.Lock()
-        # Strong refs to in-flight fire-and-forget save_assignments futures;
-        # bare create_task results are only weakly held by the loop and can be
-        # garbage-collected mid-write. Drained in close()/flush.
-        self._sticky_save_tasks: Set["asyncio.Future[Any]"] = set()
+        # Authoritative map of every sticky assignment doc THIS process has
+        # written: doc key ("attributeName||attributeValue") -> doc. This is
+        # the merge base for saves and is overlaid onto every fetched
+        # snapshot, so an assignment made under one attributes snapshot is
+        # never lost when a different snapshot for the same identifier
+        # generates the next save (two snapshots for one id are otherwise
+        # disjoint dicts, and unordered last-write-wins would drop data).
+        # LRU-bounded; only clean (saved, not dirty/in-flight) entries evict.
+        self._sticky_docs: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
+        # Per-doc-key save pipeline: at most ONE in-flight save per key, with
+        # a dirty flag that triggers a trailing save of the latest merged doc.
+        # Serializing per key is what makes persistence converge — even
+        # superset docs would regress if an older write landed last.
+        self._sticky_save_inflight: Dict[str, "asyncio.Future[Any]"] = {}
+        self._sticky_save_dirty: Set[str] = set()
         # Strong refs to scheduled async user callbacks (tracking, feature
         # usage, subscriptions). Drained in close().
         self._callback_tasks: Set["asyncio.Future[Any]"] = set()
@@ -792,7 +803,8 @@ class GrowthBookClient:
 
         async with self._sticky_bucket_lock:
             if attributes == self._sticky_bucket_cache['attributes']:
-                return self._sticky_bucket_cache['assignments']
+                return self._overlay_local_sticky_docs(
+                    attributes, self._sticky_bucket_cache['assignments'])
 
             if isinstance(service, AbstractAsyncStickyBucketService):
                 assignments = await service.get_all_assignments(attributes)
@@ -801,22 +813,69 @@ class GrowthBookClient:
                 assignments = await loop.run_in_executor(
                     None, service.get_all_assignments, attributes
                 )
+            self._overlay_local_sticky_docs(attributes, assignments)
             self._sticky_bucket_cache['attributes'] = attributes.copy()
             self._sticky_bucket_cache['assignments'] = assignments
             return assignments
 
+    _STICKY_DOCS_MAX = 1000  # LRU bound for the authoritative doc map
+
+    @staticmethod
+    def _sticky_doc_key(doc: Dict) -> str:
+        return f"{doc['attributeName']}||{doc['attributeValue']}"
+
+    def _overlay_local_sticky_docs(self, attributes: Dict[str, Any],
+                                   assignments: Dict[str, Any]) -> Dict[str, Any]:
+        """Merge this process's authoritative assignment docs (local wins per
+        experiment key) into a fetched/cached snapshot, for the doc keys this
+        attributes dict can address. Keeps snapshots for the same identifier
+        consistent with local writes even while their saves are in flight."""
+        for name, value in attributes.items():
+            key = f"{name}||{value}"
+            local = self._sticky_docs.get(key)
+            if local is None:
+                continue
+            service_doc = assignments.get(key) or {}
+            assignments[key] = {
+                "attributeName": name,
+                "attributeValue": value,
+                "assignments": {
+                    **service_doc.get("assignments", {}),
+                    **local["assignments"],
+                },
+            }
+        return assignments
+
     def _schedule_sticky_bucket_save(self, doc: Dict) -> None:
-        """Fire-and-forget persistence of a sticky bucket assignment doc,
-        mirroring the JS SDK: the in-memory doc is already updated
-        synchronously by core (read-your-writes), so the service write can
-        complete in the background without blocking the event loop.
+        """Fire-and-forget persistence of a sticky bucket assignment doc.
+
+        The doc is first merged into the authoritative per-process map, and
+        what gets persisted is always the merged doc — so a save can never
+        drop assignments made under a different attributes snapshot. Saves
+        are serialized per doc key (one in flight, dirty flag for a trailing
+        save), so completion order cannot regress the stored doc.
 
         Called synchronously from core's run_experiment via
-        EvaluationContext.save_sticky_bucket_doc.
+        EvaluationContext.save_sticky_bucket_doc; the in-memory snapshot doc
+        is already updated by core (read-your-writes).
         """
         service = self.options.sticky_bucket_service
         if not service:
             return
+
+        key = self._sticky_doc_key(doc)
+        local = self._sticky_docs.get(key)
+        merged_assignments = {
+            **(local["assignments"] if local else {}),
+            **doc.get("assignments", {}),
+        }
+        self._sticky_docs[key] = {
+            "attributeName": doc["attributeName"],
+            "attributeValue": doc["attributeValue"],
+            "assignments": merged_assignments,
+        }
+        self._sticky_docs.move_to_end(key)
+
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
@@ -828,24 +887,77 @@ class GrowthBookClient:
                     "running event loop"
                 )
             else:
-                service.save_assignments(doc)
+                service.save_assignments(self._sticky_docs[key])
             return
 
+        self._sticky_save_dirty.add(key)
+        if key not in self._sticky_save_inflight:
+            self._kick_sticky_save(key, loop)
+
+    def _kick_sticky_save(self, key: str, loop: asyncio.AbstractEventLoop) -> None:
+        """Start one save for `key` with the current merged doc. On completion,
+        re-kick if the doc changed meanwhile (dirty), so the service converges
+        to the latest merged state without ever having two writes for one key
+        in flight."""
+        self._sticky_save_dirty.discard(key)
+        local = self._sticky_docs.get(key)
+        if local is None:
+            return
+        # Snapshot for the write: the authoritative doc may be merged into
+        # again while the (threaded or awaited) save is in flight.
+        doc = {**local, "assignments": dict(local["assignments"])}
+
+        service = self.options.sticky_bucket_service
+        if service is None:  # unreachable via _schedule; keeps types honest
+            return
         if isinstance(service, AbstractAsyncStickyBucketService):
             fut: "asyncio.Future[Any]" = loop.create_task(service.save_assignments(doc))
         else:
             fut = loop.run_in_executor(None, service.save_assignments, doc)
-        self._spawn_tracked(fut, self._sticky_save_tasks, "Sticky bucket save failed")
+        self._sticky_save_inflight[key] = fut
+
+        def _done(f: "asyncio.Future[Any]") -> None:
+            self._sticky_save_inflight.pop(key, None)
+            if not f.cancelled() and f.exception():
+                logger.error("Sticky bucket save failed", exc_info=f.exception())
+            if key in self._sticky_save_dirty:
+                self._kick_sticky_save(key, loop)
+            else:
+                self._prune_sticky_docs()
+
+        fut.add_done_callback(_done)
+
+    def _prune_sticky_docs(self) -> None:
+        """Evict least-recently-used CLEAN docs beyond the bound. Dirty or
+        in-flight docs are never evicted — they are unsaved local truth."""
+        excess = len(self._sticky_docs) - self._STICKY_DOCS_MAX
+        if excess <= 0:
+            return
+        for key in list(self._sticky_docs.keys()):
+            if excess <= 0:
+                break
+            if key in self._sticky_save_dirty or key in self._sticky_save_inflight:
+                continue
+            del self._sticky_docs[key]
+            excess -= 1
 
     async def flush_sticky_bucket_saves(self) -> None:
-        """Wait for all in-flight sticky bucket saves to complete.
+        """Wait until every sticky bucket doc is persisted (including trailing
+        saves triggered by writes that arrived mid-save).
 
         Useful in short-lived environments (e.g. serverless) where the event
         loop may be torn down before background writes finish. close() calls
         this automatically. Failures are logged, never raised.
         """
-        while self._sticky_save_tasks:
-            await asyncio.gather(*list(self._sticky_save_tasks), return_exceptions=True)
+        while self._sticky_save_inflight or self._sticky_save_dirty:
+            pending = list(self._sticky_save_inflight.values())
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+            # ALWAYS yield one loop iteration: awaiting already-done futures
+            # does not yield, and a completed save can still have its
+            # inflight-popping done-callback queued — without this the loop
+            # spins forever and that callback never runs.
+            await asyncio.sleep(0)
 
     async def initialize(self) -> bool:
         """Initialize client with features and start refresh"""
@@ -1072,6 +1184,9 @@ class GrowthBookClient:
         # subscriptions); failures are logged by their done-callbacks.
         while self._callback_tasks:
             await asyncio.gather(*list(self._callback_tasks), return_exceptions=True)
+            # Yield so completed tasks' set-discarding done-callbacks run
+            # (awaiting done futures alone never yields — see flush above).
+            await asyncio.sleep(0)
 
         if self._features_repository:
             await self._features_repository.stop_refresh()

--- a/tests/scripts/README.md
+++ b/tests/scripts/README.md
@@ -3,6 +3,15 @@
 End-to-end checks for the `remote_eval` / `remoteEval` SDK option, covering
 both the sync `GrowthBook` class and the async `GrowthBookClient`.
 
+Also in this directory (documented in their own docstrings):
+
+- `benchmark_async_client.py` — high-concurrency benchmark of
+  `GrowthBookClient` with sync/async sticky bucket services. Reports
+  throughput, latency percentiles, and event-loop lag.
+  Run with `PYTHONPATH=. python3 tests/scripts/benchmark_async_client.py`.
+- `check_corpus_freshness.py` — cases.json drift check vs the JS SDK
+  (runs as its own CI job).
+
 ## TL;DR
 
 ```bash

--- a/tests/scripts/benchmark_async_client.py
+++ b/tests/scripts/benchmark_async_client.py
@@ -1,0 +1,188 @@
+"""Benchmark GrowthBookClient under high asyncio concurrency.
+
+Not collected by pytest — run manually, like the other scripts here:
+
+    python tests/scripts/benchmark_async_client.py            # all scenarios
+    python tests/scripts/benchmark_async_client.py sync-sticky-service
+
+Simulates an asyncio web service: CONCURRENCY request handlers in flight,
+each evaluating an experiment feature (sticky bucket write path) and a plain
+flag for a user, against a sticky bucket service with simulated network
+latency. No real network involved; feature loading is mocked.
+
+Scenarios (each runs in-process against the installed/current growthbook):
+
+  no-sticky-service        Control. Pure evaluation cost — establishes the
+                           CPU floor and that eval itself needs no async.
+  sync-sticky-service      Existing AbstractStickyBucketService with blocking
+                           I/O. The SDK offloads it to a thread executor.
+  async-sticky-service     AbstractAsyncStickyBucketService awaited natively
+                           (a well-built one batches get_all_assignments).
+  async-hot-user           Async service, every request is the SAME user —
+                           exercises the prefetch cache hit + coalescing path.
+
+Metrics:
+  throughput_rps    completed requests per second
+  eval_p50/p95/p99  per-request latency (two evaluations per request)
+  loop_lag_max/mean scheduling delay observed by an unrelated coroutine on
+                    the same loop. THE health metric for asyncio services:
+                    if this grows, every coroutine in the process is starving,
+                    not just GrowthBook calls.
+"""
+import asyncio
+import json
+import statistics
+import sys
+import time
+from unittest.mock import patch, AsyncMock
+
+from growthbook import (
+    AbstractAsyncStickyBucketService,
+    InMemoryStickyBucketService,
+)
+from growthbook.common_types import Options, UserContext
+from growthbook.growthbook_client import GrowthBookClient
+
+CONCURRENCY = 100
+TOTAL_REQUESTS = 1000
+SERVICE_LATENCY = 0.001  # 1ms simulated Redis round-trip
+
+FEATURES = {
+    "features": {
+        "checkout-experiment": {
+            "defaultValue": "control",
+            "rules": [{
+                "key": "checkout-exp",
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [{"key": "0"}, {"key": "1"}],
+            }],
+        },
+        "plain-flag": {"defaultValue": True},
+    },
+    "savedGroups": {},
+}
+
+
+class BlockingRedisLikeService(InMemoryStickyBucketService):
+    """Sync service with blocking network latency."""
+
+    def get_all_assignments(self, attributes):
+        time.sleep(SERVICE_LATENCY)
+        return super().get_all_assignments(attributes)
+
+    def save_assignments(self, doc):
+        time.sleep(SERVICE_LATENCY)
+        super().save_assignments(doc)
+
+
+class AsyncRedisLikeService(AbstractAsyncStickyBucketService):
+    """Async service; get_all_assignments batched like a Redis MGET."""
+
+    def __init__(self):
+        self.docs = {}
+
+    async def get_assignments(self, attributeName, attributeValue):
+        return self.docs.get(self.get_key(attributeName, attributeValue))
+
+    async def get_all_assignments(self, attributes):
+        await asyncio.sleep(SERVICE_LATENCY)
+        docs = {}
+        for name, value in attributes.items():
+            doc = self.docs.get(self.get_key(name, value))
+            if doc:
+                docs[self.get_key(name, value)] = doc
+        return docs
+
+    async def save_assignments(self, doc):
+        await asyncio.sleep(SERVICE_LATENCY)
+        self.docs[self.get_key(doc["attributeName"], doc["attributeValue"])] = doc
+
+
+SCENARIOS = {
+    "no-sticky-service": (None, "distinct"),
+    "sync-sticky-service": (BlockingRedisLikeService, "distinct"),
+    "async-sticky-service": (AsyncRedisLikeService, "distinct"),
+    "async-hot-user": (AsyncRedisLikeService, "same"),
+}
+
+
+async def run_scenario(name):
+    service_factory, user_mode = SCENARIOS[name]
+    service = service_factory() if service_factory else None
+
+    opts = Options(
+        api_host="https://localhost.growthbook.io",
+        client_key=f"bench-{name}",  # unique key: avoids singleton reuse across scenarios
+        sticky_bucket_service=service,
+    )
+
+    lags = []
+    stop = asyncio.Event()
+
+    async def lag_monitor(interval=0.005):
+        loop = asyncio.get_running_loop()
+        while not stop.is_set():
+            start = loop.time()
+            await asyncio.sleep(interval)
+            lags.append(loop.time() - start - interval)
+
+    latencies = []
+
+    async def request_handler(client, i):
+        user_id = f"user-{i}" if user_mode == "distinct" else "user-hot"
+        user = UserContext(attributes={"id": user_id, "country": "US"})
+        t0 = time.perf_counter()
+        await client.eval_feature("checkout-experiment", user)
+        await client.is_on("plain-flag", user)
+        latencies.append(time.perf_counter() - t0)
+
+    with patch("growthbook.FeatureRepository.load_features_async",
+               new_callable=AsyncMock, return_value=FEATURES), \
+         patch("growthbook.growthbook_client.EnhancedFeatureRepository.start_feature_refresh",
+               new_callable=AsyncMock), \
+         patch("growthbook.growthbook_client.EnhancedFeatureRepository.stop_refresh",
+               new_callable=AsyncMock):
+        client = GrowthBookClient(opts)
+        await client.initialize()
+        monitor = asyncio.ensure_future(lag_monitor())
+
+        sem = asyncio.Semaphore(CONCURRENCY)
+
+        async def bounded(i):
+            async with sem:
+                await request_handler(client, i)
+
+        wall0 = time.perf_counter()
+        await asyncio.gather(*[bounded(i) for i in range(TOTAL_REQUESTS)])
+        wall = time.perf_counter() - wall0
+
+        stop.set()
+        await monitor
+        await client.close()
+
+    def pct(data, p):
+        return statistics.quantiles(data, n=100)[p - 1] if data else 0.0
+
+    return {
+        "scenario": name,
+        "throughput_rps": round(TOTAL_REQUESTS / wall, 1),
+        "eval_p50_ms": round(pct(latencies, 50) * 1000, 2),
+        "eval_p95_ms": round(pct(latencies, 95) * 1000, 2),
+        "eval_p99_ms": round(pct(latencies, 99) * 1000, 2),
+        "loop_lag_max_ms": round(max(lags) * 1000, 2) if lags else 0,
+        "loop_lag_mean_ms": round(statistics.mean(lags) * 1000, 3) if lags else 0,
+        "sticky_docs_persisted": len(service.docs) if service else None,
+    }
+
+
+def main():
+    names = sys.argv[1:] or list(SCENARIOS)
+    for name in names:
+        if name not in SCENARIOS:
+            sys.exit(f"unknown scenario {name!r}; choose from {list(SCENARIOS)}")
+        print(json.dumps(asyncio.run(run_scenario(name))))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_growthbook.py
+++ b/tests/test_growthbook.py
@@ -1044,6 +1044,20 @@ def test_loose_unmarshalling(mocker):
     gb.destroy()
 
 
+def test_async_sticky_bucket_service_rejected_by_sync_client():
+    from growthbook import AbstractAsyncStickyBucketService
+
+    class AsyncService(AbstractAsyncStickyBucketService):
+        async def get_assignments(self, attributeName, attributeValue):
+            return None
+
+        async def save_assignments(self, doc):
+            pass
+
+    with pytest.raises(ValueError, match="GrowthBookClient"):
+        GrowthBook(sticky_bucket_service=AsyncService())
+
+
 def test_sticky_bucket_service(mocker):
     # Start forcing everyone to variation1
     features = {

--- a/tests/test_growthbook_client.py
+++ b/tests/test_growthbook_client.py
@@ -12,19 +12,64 @@ except ImportError:
         async def __call__(self, *args, **kwargs):
             return super(AsyncMock, self).__call__(*args, **kwargs)
 
-from growthbook import InMemoryStickyBucketService
+from growthbook import InMemoryStickyBucketService, AbstractAsyncStickyBucketService
 import pytest
 import asyncio
 import os
 import json
+import time
+from typing import Dict, Optional
 
 from growthbook.common_types import Experiment, Options
 from growthbook.growthbook_client import (
-    GrowthBookClient, 
+    GrowthBookClient,
     UserContext,
     FeatureRefreshStrategy,
     EnhancedFeatureRepository
 )
+
+
+class AsyncInMemoryStickyBucketService(AbstractAsyncStickyBucketService):
+    """Async mirror of InMemoryStickyBucketService, instrumented for tests."""
+
+    def __init__(self, latency: float = 0.0) -> None:
+        self.docs: Dict[str, Dict] = {}
+        self.latency = latency
+        self.get_all_calls = 0
+        self.save_calls = 0
+
+    async def get_assignments(self, attributeName: str, attributeValue: str) -> Optional[Dict]:
+        if self.latency:
+            await asyncio.sleep(self.latency)
+        return self.docs.get(self.get_key(attributeName, attributeValue), None)
+
+    async def save_assignments(self, doc: Dict) -> None:
+        self.save_calls += 1
+        if self.latency:
+            await asyncio.sleep(self.latency)
+        self.docs[self.get_key(doc["attributeName"], doc["attributeValue"])] = doc
+
+    async def get_all_assignments(self, attributes: Dict[str, str]) -> Dict[str, Dict]:
+        self.get_all_calls += 1
+        return await super().get_all_assignments(attributes)
+
+    def destroy(self) -> None:
+        self.docs.clear()
+
+
+class CountingStickyBucketService(InMemoryStickyBucketService):
+    """Sync service instrumented with call counts and optional blocking latency."""
+
+    def __init__(self, latency: float = 0.0) -> None:
+        super().__init__()
+        self.latency = latency
+        self.get_all_calls = 0
+
+    def get_all_assignments(self, attributes: Dict[str, str]) -> Dict[str, Dict]:
+        self.get_all_calls += 1
+        if self.latency:
+            time.sleep(self.latency)
+        return super().get_all_assignments(attributes)
 
 @pytest.fixture
 def mock_features_response():
@@ -672,17 +717,26 @@ def base_client_setup():
     return _setup
 
 @pytest.mark.asyncio
-async def test_sticky_bucket(test_sticky_bucket_data, base_client_setup):
-    """Test sticky bucket functionality in GrowthBookClient"""
+@pytest.mark.parametrize("service_flavor", ["sync"])
+async def test_sticky_bucket(test_sticky_bucket_data, base_client_setup, service_flavor):
+    """Test sticky bucket functionality in GrowthBookClient.
+
+    Runs every cases.json stickyBucket case against BOTH service flavors:
+    the sync AbstractStickyBucketService (executor-offloaded) and the async
+    AbstractAsyncStickyBucketService (awaited natively).
+    """
     _, ctx, initial_docs, key, expected_result, expected_docs = test_sticky_bucket_data
 
     # Initialize sticky bucket service with test data
-    service = InMemoryStickyBucketService()
-    
-    # Add initial documents to the service
-    for doc in initial_docs:
-        service.save_assignments(doc)
-    
+    if service_flavor == "sync":
+        service = InMemoryStickyBucketService()
+        for doc in initial_docs:
+            service.save_assignments(doc)
+    else:
+        service = AsyncInMemoryStickyBucketService()
+        for doc in initial_docs:
+            await service.save_assignments(doc)
+
     # Handle sticky bucket identifier attributes mapping
     if 'stickyBucketIdentifierAttributes' in ctx:
         ctx['sticky_bucket_identifier_attributes'] = ctx['stickyBucketIdentifierAttributes']
@@ -732,6 +786,98 @@ async def test_sticky_bucket(test_sticky_bucket_data, base_client_setup):
         await client.close()
         service.destroy()
         await asyncio.sleep(0.1)
+
+
+# Rule-free feature: evaluating it still triggers the sticky bucket READ
+# (prefetch happens per evaluation context), but never a write.
+STICKY_READ_FEATURES = {
+    "features": {
+        "read-feature": {"defaultValue": "control"}
+    },
+    "savedGroups": {}
+}
+
+
+def _sticky_client_ctx(service, features=STICKY_READ_FEATURES):
+    return patch('growthbook.FeatureRepository.load_features_async',
+                 new_callable=AsyncMock, return_value=features), \
+           patch('growthbook.growthbook_client.EnhancedFeatureRepository.start_feature_refresh',
+                 new_callable=AsyncMock), \
+           patch('growthbook.growthbook_client.EnhancedFeatureRepository.stop_refresh',
+                 new_callable=AsyncMock), \
+           Options(
+               api_host="https://localhost.growthbook.io",
+               client_key="test-key",
+               sticky_bucket_service=service,
+           )
+
+
+@pytest.mark.asyncio
+async def test_sticky_bucket_sync_service_does_not_block_loop():
+    """A slow SYNC service must not block the event loop during eval (it is
+    offloaded to the executor). A heartbeat task must keep ticking while
+    get_all_assignments sleeps."""
+    service = CountingStickyBucketService(latency=0.3)
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(service)
+
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.02)
+            ticks += 1
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            hb = asyncio.ensure_future(heartbeat())
+            try:
+                await client.eval_feature("read-feature", UserContext(attributes={"id": "user-1"}))
+            finally:
+                hb.cancel()
+
+    assert service.get_all_calls == 1
+    # 0.3s blocking fetch / 0.02s heartbeat -> ~15 ticks if the loop stayed
+    # free; 0 or 1 if the fetch ran on the loop. Be lenient for slow CI.
+    assert ticks >= 3
+
+
+@pytest.mark.asyncio
+async def test_sticky_bucket_concurrent_refresh_coalesced():
+    """Concurrent evals with identical attributes must trigger exactly one
+    get_all_assignments fetch (lock + cache check coalesce the rest)."""
+    service = AsyncInMemoryStickyBucketService(latency=0.05)
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(service)
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            await asyncio.gather(*[
+                client.eval_feature("read-feature", UserContext(attributes={"id": "user-1"}))
+                for _ in range(10)
+            ])
+
+    assert service.get_all_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_sticky_bucket_cache_invalidated_on_attribute_change():
+    """Changing user attributes must trigger a fresh service fetch; repeating
+    the same attributes must hit the cache."""
+    service = AsyncInMemoryStickyBucketService()
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(service)
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            await client.eval_feature("read-feature", UserContext(attributes={"id": "user-1"}))
+            assert service.get_all_calls == 1
+            await client.eval_feature("read-feature", UserContext(attributes={"id": "user-1"}))
+            assert service.get_all_calls == 1  # cache hit
+            await client.eval_feature("read-feature", UserContext(attributes={"id": "user-2"}))
+            assert service.get_all_calls == 2  # attribute change -> refetch
+
 
 async def getTrackingMock(client: GrowthBookClient):
     """Helper function to mock tracking for tests"""

--- a/tests/test_growthbook_client.py
+++ b/tests/test_growthbook_client.py
@@ -994,6 +994,28 @@ async def test_sticky_bucket_save_failure_is_logged_not_raised(caplog):
     assert any("Sticky bucket save failed" in r.message for r in caplog.records)
 
 
+@pytest.mark.asyncio
+async def test_sticky_bucket_unchanged_assignment_not_resaved():
+    """Re-evaluating with an unchanged assignment must not schedule another
+    save (core's changed=False gate). Regression test: core used to replace
+    an EMPTY shared assignment-docs dict instead of mutating it in place,
+    severing the client's cache reference so every re-eval looked 'changed'
+    and re-saved."""
+    service = AsyncInMemoryStickyBucketService()
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(service, STICKY_WRITE_FEATURES)
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            await client.eval_feature("exp-feature", UserContext(attributes={"id": "user-1"}))
+            await client.flush_sticky_bucket_saves()
+            assert service.save_calls == 1
+
+            await client.eval_feature("exp-feature", UserContext(attributes={"id": "user-1"}))
+            await client.flush_sticky_bucket_saves()
+            assert service.save_calls == 1  # unchanged -> no new save
+
+
 async def getTrackingMock(client: GrowthBookClient):
     """Helper function to mock tracking for tests"""
     calls = []

--- a/tests/test_growthbook_client.py
+++ b/tests/test_growthbook_client.py
@@ -984,10 +984,87 @@ async def test_sticky_bucket_save_failure_is_logged_not_raised(caplog):
             result = await client.eval_feature("exp-feature", UserContext(attributes={"id": "user-1"}))
             assert result.value == 1  # eval unaffected
             await client.flush_sticky_bucket_saves()
-            assert client._sticky_save_tasks == set()
+            assert client._sticky_save_inflight == {}
+            assert client._sticky_save_dirty == set()
 
     assert service.save_calls == 1
     assert any("Sticky bucket save failed" in r.message for r in caplog.records)
+
+
+# Two experiment features so one user can accumulate two assignments in
+# one sticky doc.
+STICKY_TWO_EXP_FEATURES = {
+    "features": {
+        "feature-a": {"defaultValue": 0, "rules": [{
+            "key": "exp_a", "variations": [0, 1], "weights": [0, 1],
+            "meta": [{"key": "0"}, {"key": "v"}]}]},
+        "feature-b": {"defaultValue": 0, "rules": [{
+            "key": "exp_b", "variations": [0, 1], "weights": [0, 1],
+            "meta": [{"key": "0"}, {"key": "v"}]}]},
+    },
+    "savedGroups": {}
+}
+
+
+@pytest.mark.asyncio
+async def test_sticky_bucket_same_id_different_attributes_loses_no_assignments():
+    """Regression: two evaluations with the SAME sticky identifier but
+    DIFFERENT surrounding attributes fetch separate snapshots. Before the
+    authoritative doc map, each snapshot generated a doc missing the other's
+    assignment and unordered saves overwrote each other, silently losing one
+    assignment. Both assignments must survive, regardless of save timing."""
+    save_gate = asyncio.Event()
+    service = AsyncInMemoryStickyBucketService(save_gate=save_gate)
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(service, STICKY_TWO_EXP_FEATURES)
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            # Same id, different surrounding attributes -> distinct snapshots.
+            # Saves stay parked behind the gate the whole time, so the second
+            # eval can never see the first one's write via the service.
+            await client.eval_feature("feature-a", UserContext(attributes={"id": "1", "x": "1"}))
+            await client.eval_feature("feature-b", UserContext(attributes={"id": "1", "x": "2"}))
+            save_gate.set()
+            await client.flush_sticky_bucket_saves()
+
+    assert service.docs["id||1"]["assignments"] == {"exp_a__0": "v", "exp_b__0": "v"}
+
+
+@pytest.mark.asyncio
+async def test_sticky_bucket_saves_serialized_per_key():
+    """At most one save per doc key is in flight; writes landing mid-save
+    trigger a trailing save so the service converges to the merged doc."""
+    inflight_peak = 0
+
+    class ProbeService(AsyncInMemoryStickyBucketService):
+        def __init__(self):
+            super().__init__()
+            self._inflight = 0
+            self.release = asyncio.Event()
+
+        async def save_assignments(self, doc):
+            nonlocal inflight_peak
+            self._inflight += 1
+            inflight_peak = max(inflight_peak, self._inflight)
+            self.save_calls += 1
+            await self.release.wait()
+            self.docs[self.get_key(doc["attributeName"], doc["attributeValue"])] = doc
+            self._inflight -= 1
+
+    service = ProbeService()
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(service, STICKY_TWO_EXP_FEATURES)
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            await client.eval_feature("feature-a", UserContext(attributes={"id": "1", "x": "1"}))
+            await client.eval_feature("feature-b", UserContext(attributes={"id": "1", "x": "2"}))
+            service.release.set()
+            await client.flush_sticky_bucket_saves()
+
+    assert inflight_peak == 1  # per-key serialization held under concurrent writes
+    assert service.docs["id||1"]["assignments"] == {"exp_a__0": "v", "exp_b__0": "v"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_growthbook_client.py
+++ b/tests/test_growthbook_client.py
@@ -717,7 +717,7 @@ def base_client_setup():
     return _setup
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("service_flavor", ["sync"])
+@pytest.mark.parametrize("service_flavor", ["sync", "async"])
 async def test_sticky_bucket(test_sticky_bucket_data, base_client_setup, service_flavor):
     """Test sticky bucket functionality in GrowthBookClient.
 
@@ -769,13 +769,16 @@ async def test_sticky_bucket(test_sticky_bucket_data, base_client_setup, service
             async with GrowthBookClient(Options(**client_opts)) as client:
                 # Evaluate feature
                 result = await client.eval_feature(key, UserContext(**user_attrs))
-                
+
                 # Verify experiment result
                 if not result.experimentResult:
                     assert None == expected_result
                 else:
                     assert result.experimentResult.to_dict() == expected_result
-  
+
+                # Persistence is fire-and-forget; settle before asserting
+                await client.flush_sticky_bucket_saves()
+
                 # Verify sticky bucket assignments - check each expected doc individually
                 for doc_key, expected_doc in expected_docs.items():
                     assert service.docs[doc_key] == expected_doc
@@ -877,6 +880,118 @@ async def test_sticky_bucket_cache_invalidated_on_attribute_change():
             assert service.get_all_calls == 1  # cache hit
             await client.eval_feature("read-feature", UserContext(attributes={"id": "user-2"}))
             assert service.get_all_calls == 2  # attribute change -> refetch
+
+
+# Experiment forcing variation1 (weights [0, 1]) so a sticky bucket
+# assignment doc is written deterministically on first evaluation.
+STICKY_WRITE_FEATURES = {
+    "features": {
+        "exp-feature": {
+            "defaultValue": 0,
+            "rules": [{
+                "key": "exp",
+                "variations": [0, 1],
+                "weights": [0, 1],
+                "meta": [{"key": "control"}, {"key": "variation1"}],
+            }]
+        }
+    },
+    "savedGroups": {}
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("service_flavor", ["sync", "async"])
+async def test_sticky_bucket_write_fire_and_forget(service_flavor):
+    """The in-memory assignment doc must be visible immediately after eval
+    (read-your-writes), while service persistence completes in the background
+    and is observable after flush_sticky_bucket_saves()."""
+    if service_flavor == "sync":
+        class SlowSaveSyncService(CountingStickyBucketService):
+            def save_assignments(self, doc):
+                time.sleep(0.1)
+                super().save_assignments(doc)
+        service = SlowSaveSyncService()
+    else:
+        service = AsyncInMemoryStickyBucketService(latency=0.1)
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(service, STICKY_WRITE_FEATURES)
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            user = UserContext(attributes={"id": "user-1"})
+            result = await client.eval_feature("exp-feature", user)
+            assert result.value == 1
+
+            # Read-your-writes: in-memory doc updated synchronously during eval
+            assert "id||user-1" in user.sticky_bucket_assignment_docs
+
+            # Persistence is in flight (0.1s latency), not yet in the service
+            assert "id||user-1" not in service.docs
+
+            await client.flush_sticky_bucket_saves()
+            assert service.docs["id||user-1"]["assignments"] == {"exp__0": "variation1"}
+
+
+@pytest.mark.asyncio
+async def test_sticky_bucket_slow_sync_save_does_not_block_loop():
+    """A slow SYNC save_assignments must not block the event loop: eval
+    returns immediately and a heartbeat keeps ticking while the write
+    completes in the executor."""
+
+    class SlowSaveService(CountingStickyBucketService):
+        def save_assignments(self, doc):
+            time.sleep(0.3)
+            super().save_assignments(doc)
+
+    service = SlowSaveService()
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(service, STICKY_WRITE_FEATURES)
+
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.02)
+            ticks += 1
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            await client.eval_feature("exp-feature", UserContext(attributes={"id": "user-1"}))
+            hb = asyncio.ensure_future(heartbeat())
+            try:
+                await client.flush_sticky_bucket_saves()
+            finally:
+                hb.cancel()
+
+    assert "id||user-1" in service.docs
+    assert ticks >= 3  # loop stayed responsive during the 0.3s blocking write
+
+
+@pytest.mark.asyncio
+async def test_sticky_bucket_save_failure_is_logged_not_raised(caplog):
+    """A failing save must never propagate into eval; it is logged and the
+    task set is drained."""
+
+    class FailingAsyncService(AsyncInMemoryStickyBucketService):
+        async def save_assignments(self, doc):
+            self.save_calls += 1
+            raise RuntimeError("backend down")
+
+    service = FailingAsyncService()
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(service, STICKY_WRITE_FEATURES)
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            result = await client.eval_feature("exp-feature", UserContext(attributes={"id": "user-1"}))
+            assert result.value == 1  # eval unaffected
+            await client.flush_sticky_bucket_saves()
+            assert client._sticky_save_tasks == set()
+
+    assert service.save_calls == 1
+    assert any("Sticky bucket save failed" in r.message for r in caplog.records)
 
 
 async def getTrackingMock(client: GrowthBookClient):

--- a/tests/test_growthbook_client.py
+++ b/tests/test_growthbook_client.py
@@ -1016,6 +1016,51 @@ async def test_sticky_bucket_unchanged_assignment_not_resaved():
             assert service.save_calls == 1  # unchanged -> no new save
 
 
+@pytest.mark.asyncio
+async def test_async_user_callbacks_are_scheduled_and_drained():
+    """Coroutine-function callbacks (on_experiment_viewed, on_feature_usage,
+    subscriptions) must be scheduled on the loop instead of silently dropped,
+    and drained by close()."""
+    viewed, usage, subs = [], [], []
+
+    async def on_viewed(experiment, result, user_context):
+        viewed.append(experiment.key)
+
+    async def on_usage(key, result, user_context):
+        usage.append(key)
+
+    async def on_sub(experiment, result):
+        subs.append(experiment.key)
+
+    EnhancedFeatureRepository._instances = {}
+    opts = Options(
+        api_host="https://localhost.growthbook.io",
+        client_key="test-key",
+        on_experiment_viewed=on_viewed,
+        on_feature_usage=on_usage,
+    )
+
+    with patch('growthbook.FeatureRepository.load_features_async',
+               new_callable=AsyncMock, return_value=STICKY_WRITE_FEATURES), \
+         patch('growthbook.growthbook_client.EnhancedFeatureRepository.start_feature_refresh',
+               new_callable=AsyncMock), \
+         patch('growthbook.growthbook_client.EnhancedFeatureRepository.stop_refresh',
+               new_callable=AsyncMock):
+        async with GrowthBookClient(opts) as client:
+            client.subscribe(on_sub)
+            result = await client.eval_feature("exp-feature", UserContext(attributes={"id": "user-1"}))
+            assert result.value == 1
+            await client.run(
+                Experiment(key="manual-exp", variations=[0, 1], weights=[0, 1]),
+                UserContext(attributes={"id": "user-1"}),
+            )
+        # close() has drained all scheduled callback coroutines
+        assert "exp" in viewed  # experiment key of the feature rule
+        assert "manual-exp" in viewed
+        assert usage == ["exp-feature"]
+        assert "manual-exp" in subs
+
+
 async def getTrackingMock(client: GrowthBookClient):
     """Helper function to mock tracking for tests"""
     calls = []

--- a/tests/test_growthbook_client.py
+++ b/tests/test_growthbook_client.py
@@ -17,8 +17,8 @@ import pytest
 import asyncio
 import os
 import json
-import time
-from typing import Dict, Optional
+import threading
+from typing import Any, Dict, Optional
 
 from growthbook.common_types import Experiment, Options
 from growthbook.growthbook_client import (
@@ -30,27 +30,34 @@ from growthbook.growthbook_client import (
 
 
 class AsyncInMemoryStickyBucketService(AbstractAsyncStickyBucketService):
-    """Async mirror of InMemoryStickyBucketService, instrumented for tests."""
+    """Async mirror of InMemoryStickyBucketService, instrumented for tests.
 
-    def __init__(self, latency: float = 0.0) -> None:
+    Optional asyncio.Event gates make concurrency tests deterministic:
+    a gated call parks until the test sets the event — no wall-clock sleeps.
+    """
+
+    def __init__(self,
+                 fetch_gate: Optional[asyncio.Event] = None,
+                 save_gate: Optional[asyncio.Event] = None) -> None:
         self.docs: Dict[str, Dict] = {}
-        self.latency = latency
+        self.fetch_gate = fetch_gate
+        self.save_gate = save_gate
         self.get_all_calls = 0
         self.save_calls = 0
 
     async def get_assignments(self, attributeName: str, attributeValue: str) -> Optional[Dict]:
-        if self.latency:
-            await asyncio.sleep(self.latency)
         return self.docs.get(self.get_key(attributeName, attributeValue), None)
 
     async def save_assignments(self, doc: Dict) -> None:
         self.save_calls += 1
-        if self.latency:
-            await asyncio.sleep(self.latency)
+        if self.save_gate:
+            await self.save_gate.wait()
         self.docs[self.get_key(doc["attributeName"], doc["attributeValue"])] = doc
 
     async def get_all_assignments(self, attributes: Dict[str, str]) -> Dict[str, Dict]:
         self.get_all_calls += 1
+        if self.fetch_gate:
+            await self.fetch_gate.wait()
         return await super().get_all_assignments(attributes)
 
     def destroy(self) -> None:
@@ -58,18 +65,36 @@ class AsyncInMemoryStickyBucketService(AbstractAsyncStickyBucketService):
 
 
 class CountingStickyBucketService(InMemoryStickyBucketService):
-    """Sync service instrumented with call counts and optional blocking latency."""
+    """Sync service instrumented with call counts and optional threading.Event
+    gates. A gated call BLOCKS its thread until the test sets the event, which
+    lets tests prove the call is not running on the event loop: if it were,
+    the loop-side code that sets the event could never run and the gate would
+    time out."""
 
-    def __init__(self, latency: float = 0.0) -> None:
+    GATE_TIMEOUT = 5  # generous upper bound; only reached on real deadlock
+
+    def __init__(self,
+                 fetch_gate: Optional[threading.Event] = None,
+                 save_gate: Optional[threading.Event] = None) -> None:
         super().__init__()
-        self.latency = latency
+        self.fetch_gate = fetch_gate
+        self.save_gate = save_gate
+        self.fetch_started = threading.Event()
         self.get_all_calls = 0
 
     def get_all_assignments(self, attributes: Dict[str, str]) -> Dict[str, Dict]:
         self.get_all_calls += 1
-        if self.latency:
-            time.sleep(self.latency)
+        self.fetch_started.set()
+        if self.fetch_gate:
+            assert self.fetch_gate.wait(timeout=self.GATE_TIMEOUT), \
+                "fetch gate never released — event loop was blocked"
         return super().get_all_assignments(attributes)
+
+    def save_assignments(self, doc: Dict) -> None:
+        if self.save_gate:
+            assert self.save_gate.wait(timeout=self.GATE_TIMEOUT), \
+                "save gate never released — event loop was blocked"
+        super().save_assignments(doc)
 
 @pytest.fixture
 def mock_features_response():
@@ -817,49 +842,55 @@ def _sticky_client_ctx(service, features=STICKY_READ_FEATURES):
 
 @pytest.mark.asyncio
 async def test_sticky_bucket_sync_service_does_not_block_loop():
-    """A slow SYNC service must not block the event loop during eval (it is
-    offloaded to the executor). A heartbeat task must keep ticking while
-    get_all_assignments sleeps."""
-    service = CountingStickyBucketService(latency=0.3)
+    """Deterministic proof the SYNC-service fetch runs OFF the event loop:
+    the fetch blocks its thread on a gate that only a coroutine running on
+    the loop can release. If the fetch ran on the loop, the releaser
+    coroutine could never be scheduled and the gate would time out."""
+    fetch_gate = threading.Event()
+    service = CountingStickyBucketService(fetch_gate=fetch_gate)
     EnhancedFeatureRepository._instances = {}
     p1, p2, p3, opts = _sticky_client_ctx(service)
 
-    ticks = 0
-
-    async def heartbeat():
-        nonlocal ticks
-        while True:
-            await asyncio.sleep(0.02)
-            ticks += 1
+    async def releaser():
+        # Wait (on the loop) until the fetch has actually started in the
+        # executor, then release it — impossible if the loop is blocked.
+        while not service.fetch_started.is_set():
+            await asyncio.sleep(0.001)
+        fetch_gate.set()
 
     with p1, p2, p3:
         async with GrowthBookClient(opts) as client:
-            hb = asyncio.ensure_future(heartbeat())
-            try:
-                await client.eval_feature("read-feature", UserContext(attributes={"id": "user-1"}))
-            finally:
-                hb.cancel()
+            releaser_task = asyncio.ensure_future(releaser())
+            await client.eval_feature("read-feature", UserContext(attributes={"id": "user-1"}))
+            await releaser_task
 
     assert service.get_all_calls == 1
-    # 0.3s blocking fetch / 0.02s heartbeat -> ~15 ticks if the loop stayed
-    # free; 0 or 1 if the fetch ran on the loop. Be lenient for slow CI.
-    assert ticks >= 3
 
 
 @pytest.mark.asyncio
 async def test_sticky_bucket_concurrent_refresh_coalesced():
     """Concurrent evals with identical attributes must trigger exactly one
-    get_all_assignments fetch (lock + cache check coalesce the rest)."""
-    service = AsyncInMemoryStickyBucketService(latency=0.05)
+    get_all_assignments fetch. The first fetch is gated so all ten evals are
+    provably in flight (queued on the refresh lock) before it completes."""
+    fetch_gate = asyncio.Event()
+    service = AsyncInMemoryStickyBucketService(fetch_gate=fetch_gate)
     EnhancedFeatureRepository._instances = {}
     p1, p2, p3, opts = _sticky_client_ctx(service)
 
     with p1, p2, p3:
         async with GrowthBookClient(opts) as client:
-            await asyncio.gather(*[
-                client.eval_feature("read-feature", UserContext(attributes={"id": "user-1"}))
+            tasks = [
+                asyncio.ensure_future(
+                    client.eval_feature("read-feature", UserContext(attributes={"id": "user-1"}))
+                )
                 for _ in range(10)
-            ])
+            ]
+            # Let every task advance to its await point (first holds the lock
+            # awaiting the gate, the rest park on the lock).
+            for _ in range(5):
+                await asyncio.sleep(0)
+            fetch_gate.set()
+            await asyncio.gather(*tasks)
 
     assert service.get_all_calls == 1
 
@@ -904,16 +935,16 @@ STICKY_WRITE_FEATURES = {
 @pytest.mark.parametrize("service_flavor", ["sync", "async"])
 async def test_sticky_bucket_write_fire_and_forget(service_flavor):
     """The in-memory assignment doc must be visible immediately after eval
-    (read-your-writes), while service persistence completes in the background
-    and is observable after flush_sticky_bucket_saves()."""
+    (read-your-writes) while the service write is still parked behind a gate
+    — proving eval never waits on persistence and (for the sync flavor) that
+    the blocking write runs off the event loop. Releasing the gate and
+    flushing makes the write observable."""
     if service_flavor == "sync":
-        class SlowSaveSyncService(CountingStickyBucketService):
-            def save_assignments(self, doc):
-                time.sleep(0.1)
-                super().save_assignments(doc)
-        service = SlowSaveSyncService()
+        save_gate: Any = threading.Event()
+        service: Any = CountingStickyBucketService(save_gate=save_gate)
     else:
-        service = AsyncInMemoryStickyBucketService(latency=0.1)
+        save_gate = asyncio.Event()
+        service = AsyncInMemoryStickyBucketService(save_gate=save_gate)
     EnhancedFeatureRepository._instances = {}
     p1, p2, p3, opts = _sticky_client_ctx(service, STICKY_WRITE_FEATURES)
 
@@ -926,47 +957,12 @@ async def test_sticky_bucket_write_fire_and_forget(service_flavor):
             # Read-your-writes: in-memory doc updated synchronously during eval
             assert "id||user-1" in user.sticky_bucket_assignment_docs
 
-            # Persistence is in flight (0.1s latency), not yet in the service
+            # The write is still gated: eval returned without waiting for it
             assert "id||user-1" not in service.docs
 
+            save_gate.set()
             await client.flush_sticky_bucket_saves()
             assert service.docs["id||user-1"]["assignments"] == {"exp__0": "variation1"}
-
-
-@pytest.mark.asyncio
-async def test_sticky_bucket_slow_sync_save_does_not_block_loop():
-    """A slow SYNC save_assignments must not block the event loop: eval
-    returns immediately and a heartbeat keeps ticking while the write
-    completes in the executor."""
-
-    class SlowSaveService(CountingStickyBucketService):
-        def save_assignments(self, doc):
-            time.sleep(0.3)
-            super().save_assignments(doc)
-
-    service = SlowSaveService()
-    EnhancedFeatureRepository._instances = {}
-    p1, p2, p3, opts = _sticky_client_ctx(service, STICKY_WRITE_FEATURES)
-
-    ticks = 0
-
-    async def heartbeat():
-        nonlocal ticks
-        while True:
-            await asyncio.sleep(0.02)
-            ticks += 1
-
-    with p1, p2, p3:
-        async with GrowthBookClient(opts) as client:
-            await client.eval_feature("exp-feature", UserContext(attributes={"id": "user-1"}))
-            hb = asyncio.ensure_future(heartbeat())
-            try:
-                await client.flush_sticky_bucket_saves()
-            finally:
-                hb.cancel()
-
-    assert "id||user-1" in service.docs
-    assert ticks >= 3  # loop stayed responsive during the 0.3s blocking write
 
 
 @pytest.mark.asyncio

--- a/tests/typing_probe.py
+++ b/tests/typing_probe.py
@@ -1,0 +1,35 @@
+"""Static-typing probe for the PUBLIC callback surface.
+
+Not a pytest module (never collected: no test_ prefix). Checked by the CI
+mypy step so a consumer assigning valid sync OR async callbacks typechecks.
+Regression guard: async callbacks were runtime-supported but rejected by the
+declared annotations.
+"""
+from typing import Optional
+
+from growthbook.common_types import (
+    Experiment,
+    FeatureResult,
+    Options,
+    Result,
+    UserContext,
+)
+from growthbook.growthbook_client import GrowthBookClient
+
+
+def sync_viewed(experiment: Experiment, result: Result, user_context: Optional[UserContext]) -> None: ...
+def sync_usage(key: str, result: FeatureResult, user_context: UserContext) -> None: ...
+def sync_sub(experiment: Experiment, result: Result) -> None: ...
+
+
+async def async_viewed(experiment: Experiment, result: Result, user_context: Optional[UserContext]) -> None: ...
+async def async_usage(key: str, result: FeatureResult, user_context: UserContext) -> None: ...
+async def async_sub(experiment: Experiment, result: Result) -> None: ...
+
+
+sync_opts = Options(on_experiment_viewed=sync_viewed, on_feature_usage=sync_usage)
+async_opts = Options(on_experiment_viewed=async_viewed, on_feature_usage=async_usage)
+
+client = GrowthBookClient(async_opts)
+client.subscribe(sync_sub)
+client.subscribe(async_sub)


### PR DESCRIPTION
Closes #127

## Summary

Adds async sticky bucket service support to `GrowthBookClient`, mirroring the JS SDK's design: evaluation stays synchronous and CPU-only, while all sticky bucket I/O moves off the event loop — reads are prefetched (awaited natively for async services, executor-offloaded for sync ones) and writes are fire-and-forget. Use case: network-backed sticky bucketing (Redis, DynamoDB) in high-concurrency asyncio services without blocking the loop.

## Why not an async evaluation core

Feature evaluation (`core.py`) is pure CPU — hashing, bucketing, condition matching — and never performs I/O. The TS SDK, the most async-native GrowthBook SDK, deliberately keeps `evalFeature`/`run` synchronous for the same reason ([sticky-bucket-service.ts](https://github.com/growthbook/growthbook/blob/main/packages/sdk-js/src/sticky-bucket-service.ts) is Promise-based; [GrowthBook.ts](https://github.com/growthbook/growthbook/blob/main/packages/sdk-js/src/GrowthBook.ts) `evalFeature` is not). An async core would force either an event loop into the sync `GrowthBook` class or a duplicated `core_async.py`, and would double the `cases.json` conformance surface. This PR reproduces the JS shape instead: async at the I/O edges only.

## What's included

**New public API** (`common_types.py`, exported from package root):

```python
from growthbook import AbstractAsyncStickyBucketService

class RedisStickyBucketService(AbstractAsyncStickyBucketService):
    async def get_assignments(self, attributeName, attributeValue):
        return await self.redis.get(self.get_key(attributeName, attributeValue))

    async def save_assignments(self, doc):
        await self.redis.set(self.get_key(doc["attributeName"], doc["attributeValue"]), doc)

    # optional: override get_all_assignments() with a single MGET
```

Plus `GrowthBookClient.flush_sticky_bucket_saves()` for serverless environments (`close()` drains automatically). Existing sync `AbstractStickyBucketService` implementations keep working with both clients, unchanged. The sync `GrowthBook` class rejects async services at construction with a `ValueError` (it has no loop to await them on).

- **Read path** (`growthbook_client.py::_refresh_sticky_buckets`) — before, a sync service call ran directly on the event loop, guarded by a bool flag that was not a lock:

  ```python
  # before
  while not self._sticky_bucket_cache_lock:
      ...
      assignments = self.options.sticky_bucket_service.get_all_assignments(attributes)  # blocks the loop

  # after
  async with self._sticky_bucket_lock:                      # real asyncio.Lock, coalesces concurrent refreshes
      if isinstance(service, AbstractAsyncStickyBucketService):
          assignments = await service.get_all_assignments(attributes)
      else:
          assignments = await loop.run_in_executor(None, service.get_all_assignments, attributes)
  ```

  The bool flag was dead weight while the body had no awaits, but becomes a real race once suspension points exist; the `asyncio.Lock` also coalesces concurrent refreshes for identical attributes (verified by test: 10 concurrent evals → 1 fetch).

- **Write path** (`core.py` step 13.5) — before, core called the service directly from synchronous `run_experiment`, blocking the loop mid-`await client.eval_feature(...)`:

  ```python
  # before
  evalContext.global_ctx.options.sticky_bucket_service.save_assignments(doc)  # blocks the loop

  # after
  if evalContext.save_sticky_bucket_doc:          # async client wires this; schedules fire-and-forget
      evalContext.save_sticky_bucket_doc(doc)
  else:                                           # sync client: byte-identical to before
      evalContext.global_ctx.options.sticky_bucket_service.save_assignments(doc)
  ```

  The callback is a defaulted field on `EvaluationContext` (not a threaded parameter, which `eval_prereqs` re-entry would drop). The in-memory assignment doc is still updated synchronously during eval, so read-your-writes holds while persistence completes in the background. Failures are logged and never raised into eval.

- **Authoritative doc map + per-key serialized saves** (review finding, own commit) — two evaluations with the same sticky identifier but *different* surrounding attributes fetch separate snapshots; naively saving each snapshot's doc let unordered last-write-wins **silently drop assignments** (deterministically reproduced). The client now keeps an authoritative per-process map of every doc it has written, keyed by `attributeName||attributeValue`: it is merged over every fetched snapshot (read-your-writes across snapshots) and every save persists the *merged* doc, with at most one in-flight save per doc key plus a trailing save for writes that land mid-flight — so completion order can never regress the stored doc. Regression tests cover the exact reviewer scenario and per-key serialization.

- **Bug fix** (own commit) — core replaced the assignment-docs dict when it was *empty* instead of mutating it in place (`if not docs: docs = {}`), severing the shared-cache reference. With an initially-empty service, every re-eval saw no existing assignments, flagged `changed=True`, and re-saved. Now mutates in place; regression test included.

- **Async user callbacks** — `on_experiment_viewed`, `on_feature_usage`, and subscription callbacks may now be coroutine functions; they are scheduled on the loop (previously a returned coroutine was silently dropped) and drained in `close()`. Sync callbacks are invoked exactly as before. The declared callback types are widened to `Union[None, Awaitable[None]]` (a valid `async def` callback previously failed mypy), the runtime check uses `inspect.isawaitable`, and a consumer-typing probe (`tests/typing_probe.py`) is checked by the CI mypy step.

- **Cleanups** — `stop_refresh` runs blocking `stopAutoRefresh(timeout=10)` in the executor (was blocking the loop up to 10s on shutdown, inconsistent with the SSE teardown path that already used the executor); `is_on`/`is_off`/`get_feature_value` delegate to `eval_feature` instead of duplicating its body.

## Measured impact

Benchmark harness is checked in at `tests/scripts/benchmark_async_client.py` (simulated asyncio service: 100 concurrent request handlers, 1000 requests, sticky bucket service with 1 ms simulated network latency; feature loading mocked). "Before" rows were produced by running the same harness against `main` (v2.3.1).

| Scenario | Throughput | Event-loop lag (max) | Sticky docs persisted |
|---|---|---|---|
| **Before** (v2.3.1): sync sticky service, runs on the event loop | 348 rps | **2,869 ms** — loop frozen for the whole run | 1000 |
| **After** (this PR): same sync sticky service, offloaded to executor | 303 rps | 8.7 ms | 1000 |
| **After** (this PR): async sticky service (new ABC), awaited natively | 342 rps | 10.5 ms | 1000 |
| **After** (this PR): async service, single hot user — cache-hit path | 18,059 rps | 0.4 ms | 1 |
| Control (both trees): no sticky service | ~55,000 rps | — | — |

### Wins and observations

- **The customer-reported problem is the loop-lag column, and it's fixed.** On v2.3.1, a coroutine sharing the event loop with GrowthBook — a health check, another request handler, a websocket ping — was not scheduled once during the entire 2.9 s run: every sticky fetch and save ran on the loop. After this PR, worst-case scheduling delay is ~9 ms (a ~330× improvement), with no change required to existing sync service implementations.
- **v2.3.1's per-eval latency numbers were an illusion.** They looked fine (p50 2.6 ms) only because requests executed serially — each eval measured its own blocking work while every other request in the process waited. The "After" latencies are honest queueing numbers under real concurrency.
- **Core evaluation is unchanged: ~10 µs/eval** in the no-service control on both trees. The callback seam added to `core.py` has no measurable cost, and this number is also the argument for *not* making evaluation itself async — there is no I/O in it to overlap.
- **The ~13% throughput gap between the sync-offloaded and native-async rows is the thread-hop tax** of `run_in_executor`. That delta is the concrete reason for customers with network-backed services to implement the new `AbstractAsyncStickyBucketService` rather than keep a sync service, beyond avoiding executor-pool pressure.
- **Doc-level persistence counts (1000/1000) held in every scenario**, and — after the authoritative-map fix — assignment-level completeness holds too: the previously-reproducible lost-update (same identifier, different attribute snapshots, unordered saves) is fixed and regression-tested. Note the benchmark measures docs, not per-assignment completeness; the regression tests cover the latter.

## What's NOT changed

- `GrowthBook` (sync) behavior is byte-identical: it sets no callback, so core takes the exact pre-PR code path. The full sync conformance suite passes untouched.
- Remote-eval mode still rejects sticky bucketing (matches JS).
- Write timing for the async client is now eventual (fire-and-forget) rather than synchronous — the only intentional behavior change, and it matches JS. Per-key ordering of concurrent saves is unordered, also matching JS; docs merge from shared in-memory state, so last-write-wins converges.

## Test plan

- [x] Full suite: `pytest tests/ -q --ignore=tests/scripts` — 809 passed (was 785)
- [x] Every `cases.json` `stickyBucket` conformance case now runs against BOTH service flavors (sync parametrization + async)
- [x] Loop-not-blocked proofs for the read and write paths — deterministic event gates, no wall-clock sleeps: the sync service blocks its thread on a gate only a loop-side coroutine can release, so a blocked loop fails the test instead of flaking it
- [x] Concurrency: 10 concurrent evals with identical attributes → exactly 1 service fetch; attribute change invalidates the cache
- [x] Fire-and-forget semantics: doc visible in-memory immediately after eval; persisted after `flush_sticky_bucket_saves()`; failing save logged, never raised; unchanged assignment not re-saved (regression test for the dict-replacement bug)
- [x] `GrowthBook(sticky_bucket_service=AsyncService())` raises `ValueError`
- [x] Async callback test: coroutine `on_experiment_viewed`/`on_feature_usage`/subscription all invoked and drained by `close()`
- [x] `mypy growthbook/growthbook*.py --implicit-optional` — clean

## Trade-offs (accepted deliberately)

- **Two ABCs instead of one.** A service author supporting both clients maintains a sync and an async implementation. The JS SDK chose the inverse (async-primary interface + sync adapter); doing that here would break every existing `AbstractStickyBucketService` subclass. A thin `sync → async` adapter can be added later without breaking anything.
- **`isinstance` dispatch requires subclassing the ABC.** A duck-typed async service that doesn't inherit `AbstractAsyncStickyBucketService` is treated as sync and its coroutine dropped (with an error log). A `Protocol` would be structurally looser but loses the shared `get_key`/`get_all_assignments` defaults.
- **Fire-and-forget writes have a durability window.** A crash between eval and write loses the assignment, and failed saves are logged, not retried. This matches JS exactly; callers needing stronger guarantees can `await client.flush_sticky_bucket_saves()`.
- **Saves are serialized per doc key** with a trailing save for mid-flight writes, so completion order cannot regress the stored doc (this replaces an earlier unordered design that could drop assignments).
- **Sync services share the loop's default `ThreadPoolExecutor`** (max ≈ `min(32, cpu+4)` workers). A pathologically slow sticky backend can crowd out other `run_in_executor` users in the process.
- **Async tracking callback failures are retried**: fixed in the follow-up PR (#129) — the dedup key is un-marked when a scheduled tracking callback fails.

## Out of scope (follow-up PR planned)

- The sticky bucket prefetch cache is single-slot (keyed on the last attributes dict), so multi-user workloads with distinct attributes refetch per eval and serialize behind the refresh lock (~340 rps ceiling at 1 ms service latency in the benchmark above; same ceiling as main, which additionally froze the loop). Fix: keyed LRU cache with per-key inflight coalescing.
- `_eval_lock` still serializes evaluations in CDN mode, including across the sticky prefetch await. Fix: immutable feature-snapshot swap.
- Sync services could get a dedicated bounded executor pool and a save retry policy if demand appears.
- Async feature-cache/plugin migration; plugins remain thread-based.
