### PR TITLE
Keyed sticky prefetch cache, lock-free evaluation, tracking retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,57 @@ gb = GrowthBook(
 )
 ```
 
+### Async Sticky Bucketing (GrowthBookClient)
+
+The async `GrowthBookClient` supports network-backed sticky bucket services (Redis, DynamoDB, etc.) without blocking the event loop. There are two options:
+
+- **Async services** — subclass `AbstractAsyncStickyBucketService` and implement `async` versions of `get_assignments` / `save_assignments`. Optionally override `get_all_assignments` to batch lookups into one round trip (e.g. a single Redis `MGET`).
+- **Existing sync services** — any `AbstractStickyBucketService` subclass also works with `GrowthBookClient` unchanged; its blocking calls are offloaded to a thread pool.
+
+```python
+import json
+from growthbook import AbstractAsyncStickyBucketService, GrowthBookClient, Options
+
+class RedisStickyBucketService(AbstractAsyncStickyBucketService):
+    def __init__(self, redis):  # e.g. redis.asyncio.Redis
+        self.redis = redis
+
+    async def get_assignments(self, attributeName: str, attributeValue: str):
+        raw = await self.redis.get(self.get_key(attributeName, attributeValue))
+        return json.loads(raw) if raw else None
+
+    async def save_assignments(self, doc: dict) -> None:
+        key = self.get_key(doc["attributeName"], doc["attributeValue"])
+        await self.redis.set(key, json.dumps(doc))
+
+    # Optional: batch all lookups for a user into a single MGET
+    async def get_all_assignments(self, attributes: dict):
+        keys = [self.get_key(k, v) for k, v in attributes.items()]
+        docs = {}
+        for raw in await self.redis.mget(keys):
+            if raw:
+                doc = json.loads(raw)
+                docs[self.get_key(doc["attributeName"], doc["attributeValue"])] = doc
+        return docs
+
+client = GrowthBookClient(Options(
+    api_host="https://cdn.growthbook.io",
+    client_key="sdk-abc123",
+    sticky_bucket_service=RedisStickyBucketService(redis),
+))
+```
+
+Behaviors to be aware of:
+
+- **Reads are per evaluation.** Assignments are fetched for the supplied `UserContext` on each evaluation, matching the JavaScript SDK's multi-user client. Concurrent evaluations for the same user share one in-flight lookup. To trade staleness for fewer lookups on hot users, opt into a bounded cache with `Options(sticky_bucket_cache_ttl=30, sticky_bucket_cache_size=1000)` (seconds / max users; disabled by default).
+- **Writes are fire-and-forget.** Evaluation never waits on persistence. New assignments are immediately visible to later evaluations in the same process (the client keeps an authoritative in-process copy of every document it has written, so a slow or stale store read can never roll back an assignment). Writes from *other* processes become visible on the next fetch.
+- **Flushing.** `await client.flush_sticky_bucket_saves()` waits for all pending writes to persist — useful in serverless environments and tests. `await client.close()` flushes automatically.
+- The synchronous `GrowthBook` class only accepts synchronous services; passing an async service raises `ValueError` at construction.
+
+### Async Callbacks (GrowthBookClient)
+
+With `GrowthBookClient`, the `on_experiment_viewed` and `on_feature_usage` options — and callbacks registered via `client.subscribe()` — may be either regular functions or coroutines. Coroutine callbacks are scheduled on the event loop without blocking evaluation, and a tracking callback that raises is retried on the next evaluation of the same experiment/user pair.
+
 ## Inline Experiments
 
 Instead of declaring all features up-front and referencing them by ids in your code, you can also just run an experiment directly. This is done with the `run` method:

--- a/growthbook/common_types.py
+++ b/growthbook/common_types.py
@@ -459,6 +459,14 @@ class Options:
     remote_eval: bool = False
     cache_key_attributes: Optional[List[str]] = None
     remote_eval_cache_size: int = 1000
+    # Opt-in sticky bucket prefetch cache for the async client. 0 (default)
+    # disables caching: assignments are fetched per evaluation context,
+    # matching the JS SDK's server-side GrowthBookClient. When > 0, fetched
+    # assignments are reused for this many seconds per attributes dict
+    # (bounded staleness across workers), LRU-bounded by
+    # sticky_bucket_cache_size. Non-positive values disable caching.
+    sticky_bucket_cache_ttl: float = 0
+    sticky_bucket_cache_size: int = 1000
 
 
 @dataclass

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -618,12 +618,12 @@ class GrowthBookClient:
         self._subscriptions: Set[Callable[[Experiment, Result], Union[None, Awaitable[None]]]] = set()
         self._subscriptions_lock = threading.Lock()
 
-        # Add sticky bucket cache
-        self._sticky_bucket_cache: Dict[str, Dict[str, Any]] = {
-            'attributes': {},
-            'assignments': {}
-        }
-        self._sticky_bucket_lock = asyncio.Lock()
+        # Per-attributes-key inflight sticky bucket fetches. Concurrent evals
+        # with identical attributes coalesce onto one service fetch; distinct
+        # attributes fetch in parallel. No cross-eval result cache by default
+        # — assignments are fetched per evaluation context, matching the JS
+        # SDK's server-side GrowthBookClient.applyStickyBuckets.
+        self._sticky_bucket_inflight: Dict[str, "asyncio.Future[Dict[str, Any]]"] = {}
         # Authoritative map of every sticky assignment doc THIS process has
         # written: doc key ("attributeName||attributeValue") -> doc. This is
         # the merge base for saves and is overlaid onto every fetched
@@ -808,33 +808,57 @@ class GrowthBookClient:
         
     
     async def _refresh_sticky_buckets(self, attributes: Dict[str, Any]) -> Dict[str, Any]:
-        """Refresh sticky bucket assignments only if attributes have changed.
+        """Fetch sticky bucket assignments for these attributes.
 
         Never blocks the event loop: async services are awaited natively, sync
-        services are offloaded to the default executor. The lock also coalesces
-        concurrent refreshes for identical attributes — waiters hit the cache
-        check after the first fetch completes.
+        services are offloaded to the default executor. Concurrent evals with
+        identical attributes share one inflight fetch; waiters are shielded so
+        one cancelled waiter cannot poison the shared future, and if the OWNER
+        is cancelled, waiters retry (one becomes the new owner).
         """
         service = self.options.sticky_bucket_service
         if not service:
             return {}
 
-        async with self._sticky_bucket_lock:
-            if attributes == self._sticky_bucket_cache['attributes']:
-                return self._overlay_local_sticky_docs(
-                    attributes, self._sticky_bucket_cache['assignments'])
+        key = json.dumps(attributes, sort_keys=True, default=str)
 
+        while True:
+            inflight = self._sticky_bucket_inflight.get(key)
+            if inflight is None:
+                break
+            try:
+                return await asyncio.shield(inflight)
+            except asyncio.CancelledError:
+                if not inflight.cancelled():
+                    raise  # WE were cancelled; the owner fetch continues
+                continue  # owner was cancelled; retry (maybe become owner)
+
+        loop = asyncio.get_running_loop()
+        fut: "asyncio.Future[Dict[str, Any]]" = loop.create_future()
+        self._sticky_bucket_inflight[key] = fut
+        try:
             if isinstance(service, AbstractAsyncStickyBucketService):
                 assignments = await service.get_all_assignments(attributes)
             else:
-                loop = asyncio.get_running_loop()
                 assignments = await loop.run_in_executor(
                     None, service.get_all_assignments, attributes
                 )
             self._overlay_local_sticky_docs(attributes, assignments)
-            self._sticky_bucket_cache['attributes'] = attributes.copy()
-            self._sticky_bucket_cache['assignments'] = assignments
-            return assignments
+        except asyncio.CancelledError:
+            if not fut.cancelled():
+                fut.cancel()
+            raise
+        except Exception as e:
+            if not fut.done():
+                fut.set_exception(e)
+                fut.exception()  # mark retrieved: no GC warning if unawaited
+            raise
+        finally:
+            self._sticky_bucket_inflight.pop(key, None)
+
+        if not fut.done():
+            fut.set_result(assignments)
+        return assignments
 
     _STICKY_DOCS_MAX = 1000  # LRU bound for the authoritative doc map
 

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -624,6 +624,14 @@ class GrowthBookClient:
         # — assignments are fetched per evaluation context, matching the JS
         # SDK's server-side GrowthBookClient.applyStickyBuckets.
         self._sticky_bucket_inflight: Dict[str, "asyncio.Future[Dict[str, Any]]"] = {}
+        # Opt-in TTL cache (Options.sticky_bucket_cache_ttl > 0): trades
+        # bounded cross-worker staleness for fewer service round-trips.
+        # Non-positive ttl or size disables caching entirely.
+        self._sticky_cache_enabled = (
+            (self.options.sticky_bucket_cache_ttl or 0) > 0
+            and (self.options.sticky_bucket_cache_size or 0) > 0
+        )
+        self._sticky_bucket_cache: "OrderedDict[str, Any]" = OrderedDict()
         # Authoritative map of every sticky assignment doc THIS process has
         # written: doc key ("attributeName||attributeValue") -> doc. This is
         # the merge base for saves and is overlaid onto every fetched
@@ -822,6 +830,17 @@ class GrowthBookClient:
 
         key = json.dumps(attributes, sort_keys=True, default=str)
 
+        if self._sticky_cache_enabled:
+            entry = self._sticky_bucket_cache.get(key)
+            if entry is not None:
+                cached_assignments, expires_at = entry
+                if time.monotonic() < expires_at:
+                    self._sticky_bucket_cache.move_to_end(key)
+                    # Re-apply local writes: another snapshot for the same
+                    # identifier may have assigned since this entry was cached.
+                    return self._overlay_local_sticky_docs(attributes, cached_assignments)
+                del self._sticky_bucket_cache[key]
+
         while True:
             inflight = self._sticky_bucket_inflight.get(key)
             if inflight is None:
@@ -855,6 +874,15 @@ class GrowthBookClient:
             raise
         finally:
             self._sticky_bucket_inflight.pop(key, None)
+
+        if self._sticky_cache_enabled:
+            self._sticky_bucket_cache[key] = (
+                assignments,
+                time.monotonic() + self.options.sticky_bucket_cache_ttl,
+            )
+            self._sticky_bucket_cache.move_to_end(key)
+            while len(self._sticky_bucket_cache) > self.options.sticky_bucket_cache_size:
+                self._sticky_bucket_cache.popitem(last=False)
 
         if not fut.done():
             fut.set_result(assignments)

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -681,13 +681,16 @@ class GrowthBookClient:
 
         fut.add_done_callback(_done)
 
-    def _run_user_callback(self, callback: Callable, args: tuple, what: str) -> None:
+    def _run_user_callback(self, callback: Callable, args: tuple, what: str,
+                           on_error: Optional[Callable[[], None]] = None) -> None:
         """Invoke a user callback that may be sync or async.
 
         Called from synchronous eval paths, so a returned awaitable cannot be
         awaited here; it is scheduled fire-and-forget on the running loop
         (drained in close()). Sync exceptions propagate to the caller's
-        existing try/except."""
+        existing try/except. `on_error` fires if the SCHEDULED coroutine
+        fails or cannot be scheduled — sync failures don't need it because
+        they propagate."""
         result = callback(*args)
         if inspect.isawaitable(result):
             try:
@@ -696,12 +699,16 @@ class GrowthBookClient:
                 if asyncio.iscoroutine(result):
                     result.close()
                 logger.error("Async %s callback requires a running event loop; dropped", what)
+                if on_error:
+                    on_error()
                 return
-            self._spawn_tracked(
-                asyncio.ensure_future(result),
-                self._callback_tasks,
-                f"Error in {what} callback",
-            )
+            fut = asyncio.ensure_future(result)
+            if on_error is not None:
+                def _fire_on_error(f: "asyncio.Future[Any]") -> None:
+                    if not f.cancelled() and f.exception():
+                        on_error()
+                fut.add_done_callback(_fire_on_error)
+            self._spawn_tracked(fut, self._callback_tasks, f"Error in {what} callback")
 
     def _track(self, experiment: Experiment, result: Result, user_context: UserContext) -> None:
         """Thread-safe tracking implementation"""
@@ -723,10 +730,19 @@ class GrowthBookClient:
                         self.options.on_experiment_viewed,
                         (experiment, result, user_context),
                         "tracking",
+                        # An async tracking callback is deduped at schedule
+                        # time; if it later fails, un-mark so the impression
+                        # is retried on the next eval — same retry semantics
+                        # as a sync callback that raises.
+                        on_error=lambda: self._untrack(key),
                     )
                     self._tracked[key] = True
                 except Exception:
                     logger.exception("Error in tracking callback")
+
+    def _untrack(self, key: str) -> None:
+        with self._tracked_lock:
+            self._tracked.pop(key, None)
 
     def subscribe(self, callback: Callable[[Experiment, Result], Union[None, Awaitable[None]]]) -> Callable[[], None]:
         """Thread-safe subscription management"""

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -1047,17 +1047,17 @@ class GrowthBookClient:
             logger.warning("Warning: Received empty features data")
             return
 
-        async with self._context_lock:
+        async with self._context_lock:  # serializes concurrent updaters only
             features = features_from_dict(features_data.get("features"))
             saved_groups = features_data.get("savedGroups", {})
 
-            if self._global_context is None:
-                self._global_context = GlobalContext(
-                    options=self.options, features=features, saved_groups=saved_groups
-                )
-            else:
-                self._global_context.features = features
-                self._global_context.saved_groups = saved_groups
+            # Build a NEW immutable snapshot and swap the reference atomically
+            # (single assignment). In-flight evaluations captured the previous
+            # snapshot and finish against it; new evaluations see this one.
+            # This is what lets evaluations run without any lock.
+            self._global_context = GlobalContext(
+                options=self.options, features=features, saved_groups=saved_groups
+            )
 
     async def __aenter__(self):
         await self.initialize()
@@ -1068,7 +1068,10 @@ class GrowthBookClient:
 
     async def create_evaluation_context(self, user_context: UserContext) -> EvaluationContext:
         """Create evaluation context for feature evaluation"""
-        if self._global_context is None:
+        # Capture the snapshot once; feature updates swap the reference, so
+        # this evaluation runs against a consistent view without locking.
+        global_context = self._global_context
+        if global_context is None:
             raise RuntimeError("GrowthBook client not properly initialized")
 
         if self.options.remote_eval and self._features_repository:
@@ -1105,7 +1108,7 @@ class GrowthBookClient:
 
         return EvaluationContext(
             user=user_context,
-            global_ctx=self._global_context,
+            global_ctx=global_context,
             stack=StackContext(evaluated_features=set()),
             save_sticky_bucket_doc=(
                 self._schedule_sticky_bucket_save
@@ -1113,41 +1116,23 @@ class GrowthBookClient:
             ),
         )
 
-    @asynccontextmanager
-    async def _eval_lock(self):
-        """Lock for the duration of an evaluation.
-
-        In CDN mode this guards against `_global_context` mutations (the
-        shared features dict) during `create_evaluation_context` +
-        `core_eval_feature`.
-
-        In remote-eval mode the EvaluationContext is built fresh per-call
-        from the per-user POST response — no shared state to guard, and
-        holding the lock across the network round-trip would serialize all
-        evaluations through one POST even for unrelated users (a real
-        throughput cliff on busy services)."""
-        if self.options.remote_eval:
-            yield
-        else:
-            async with self._context_lock:
-                yield
-
     async def eval_feature(self, key: str, user_context: UserContext) -> FeatureResult:
-        """Evaluate a feature with proper async context management"""
-        async with self._eval_lock():
-            context = await self.create_evaluation_context(user_context)
-            result = core_eval_feature(key=key, evalContext=context, tracking_cb=self._track)
-            # Call feature usage callback if provided
-            if self.options.on_feature_usage:
-                try:
-                    self._run_user_callback(
-                        self.options.on_feature_usage,
-                        (key, result, user_context),
-                        "feature usage",
-                    )
-                except Exception:
-                    logger.exception("Error in feature usage callback")
-            return result
+        """Evaluate a feature. Lock-free: the evaluation context captures an
+        immutable feature snapshot, so concurrent evaluations never contend
+        with each other or with feature updates."""
+        context = await self.create_evaluation_context(user_context)
+        result = core_eval_feature(key=key, evalContext=context, tracking_cb=self._track)
+        # Call feature usage callback if provided
+        if self.options.on_feature_usage:
+            try:
+                self._run_user_callback(
+                    self.options.on_feature_usage,
+                    (key, result, user_context),
+                    "feature usage",
+                )
+            except Exception:
+                logger.exception("Error in feature usage callback")
+        return result
 
     async def is_on(self, key: str, user_context: UserContext) -> bool:
         """Check if a feature is enabled with proper async context management"""
@@ -1164,17 +1149,16 @@ class GrowthBookClient:
         return result.value if result.value is not None else fallback
 
     async def run(self, experiment: Experiment, user_context: UserContext) -> Result:
-        """Run experiment with tracking"""
-        async with self._eval_lock():
-            context = await self.create_evaluation_context(user_context)
-            result = run_experiment(
-                experiment=experiment, 
-                evalContext=context,
-                tracking_cb=self._track
-            )
-            # Fire subscriptions synchronously
-            self._fire_subscriptions(experiment, result)
-            return result
+        """Run experiment with tracking. Lock-free, same as eval_feature."""
+        context = await self.create_evaluation_context(user_context)
+        result = run_experiment(
+            experiment=experiment,
+            evalContext=context,
+            tracking_cb=self._track
+        )
+        # Fire subscriptions synchronously
+        self._fire_subscriptions(experiment, result)
+        return result
         
     async def close(self) -> None:
         """Clean shutdown with proper cleanup"""

--- a/tests/test_growthbook_client.py
+++ b/tests/test_growthbook_client.py
@@ -896,9 +896,11 @@ async def test_sticky_bucket_concurrent_refresh_coalesced():
 
 
 @pytest.mark.asyncio
-async def test_sticky_bucket_cache_invalidated_on_attribute_change():
-    """Changing user attributes must trigger a fresh service fetch; repeating
-    the same attributes must hit the cache."""
+async def test_sticky_bucket_fetched_per_evaluation():
+    """No cross-eval result cache by default (parity with the JS SDK's
+    server-side GrowthBookClient.applyStickyBuckets): every evaluation
+    fetches assignments for its context, so writes from other workers are
+    visible on the next eval instead of being masked indefinitely."""
     service = AsyncInMemoryStickyBucketService()
     EnhancedFeatureRepository._instances = {}
     p1, p2, p3, opts = _sticky_client_ctx(service)
@@ -908,9 +910,102 @@ async def test_sticky_bucket_cache_invalidated_on_attribute_change():
             await client.eval_feature("read-feature", UserContext(attributes={"id": "user-1"}))
             assert service.get_all_calls == 1
             await client.eval_feature("read-feature", UserContext(attributes={"id": "user-1"}))
-            assert service.get_all_calls == 1  # cache hit
+            assert service.get_all_calls == 2  # sequential evals refetch
             await client.eval_feature("read-feature", UserContext(attributes={"id": "user-2"}))
-            assert service.get_all_calls == 2  # attribute change -> refetch
+            assert service.get_all_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_sticky_bucket_distinct_users_fetch_in_parallel():
+    """Fetches for DIFFERENT attribute sets must overlap, not serialize.
+    With the first user's fetch still parked behind the gate, the other
+    users' fetches must also have started — impossible under a global
+    refresh lock or an eval-wide lock."""
+    fetch_gate = asyncio.Event()
+    service = AsyncInMemoryStickyBucketService(fetch_gate=fetch_gate)
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(service)
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            tasks = [
+                asyncio.ensure_future(
+                    client.eval_feature("read-feature", UserContext(attributes={"id": uid}))
+                )
+                for uid in ("user-1", "user-2", "user-3")
+            ]
+            for _ in range(10):
+                await asyncio.sleep(0)
+            # All three fetches are in flight concurrently
+            assert service.get_all_calls == 3
+            fetch_gate.set()
+            await asyncio.gather(*tasks)
+
+
+@pytest.mark.asyncio
+async def test_sticky_bucket_waiter_cancellation_does_not_poison_owner():
+    """Regression: a cancelled coalesced waiter used to propagate its
+    cancellation into the shared inflight future, making the OWNER's
+    successful fetch die with InvalidStateError. Waiters are shielded now."""
+    fetch_gate = asyncio.Event()
+    service = AsyncInMemoryStickyBucketService(fetch_gate=fetch_gate)
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(service)
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            user = {"id": "user-1"}
+            owner = asyncio.ensure_future(
+                client.eval_feature("read-feature", UserContext(attributes=dict(user))))
+            for _ in range(3):
+                await asyncio.sleep(0)
+            waiter = asyncio.ensure_future(
+                client.eval_feature("read-feature", UserContext(attributes=dict(user))))
+            for _ in range(3):
+                await asyncio.sleep(0)
+            waiter.cancel()
+            for _ in range(3):
+                await asyncio.sleep(0)
+            fetch_gate.set()
+
+            result = await owner  # owner must complete normally
+            assert result.value == "control"
+            with pytest.raises(asyncio.CancelledError):
+                await waiter
+    assert service.get_all_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_sticky_bucket_owner_cancellation_waiter_retries():
+    """If the fetch OWNER is cancelled, a coalesced waiter must not be
+    collaterally cancelled: it retries, becomes the new owner, and its
+    evaluation succeeds."""
+    fetch_gate = asyncio.Event()
+    service = AsyncInMemoryStickyBucketService(fetch_gate=fetch_gate)
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(service)
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            user = {"id": "user-1"}
+            owner = asyncio.ensure_future(
+                client.eval_feature("read-feature", UserContext(attributes=dict(user))))
+            for _ in range(3):
+                await asyncio.sleep(0)
+            waiter = asyncio.ensure_future(
+                client.eval_feature("read-feature", UserContext(attributes=dict(user))))
+            for _ in range(3):
+                await asyncio.sleep(0)
+            owner.cancel()
+            for _ in range(3):
+                await asyncio.sleep(0)
+            fetch_gate.set()
+
+            result = await waiter  # waiter retried as the new owner
+            assert result.value == "control"
+            with pytest.raises(asyncio.CancelledError):
+                await owner
+    assert service.get_all_calls == 2  # aborted owner fetch + waiter's retry
 
 
 @pytest.mark.asyncio

--- a/tests/test_growthbook_client.py
+++ b/tests/test_growthbook_client.py
@@ -826,7 +826,7 @@ STICKY_READ_FEATURES = {
 }
 
 
-def _sticky_client_ctx(service, features=STICKY_READ_FEATURES):
+def _sticky_client_ctx(service, features=STICKY_READ_FEATURES, **opt_kwargs):
     return patch('growthbook.FeatureRepository.load_features_async',
                  new_callable=AsyncMock, return_value=features), \
            patch('growthbook.growthbook_client.EnhancedFeatureRepository.start_feature_refresh',
@@ -837,6 +837,7 @@ def _sticky_client_ctx(service, features=STICKY_READ_FEATURES):
                api_host="https://localhost.growthbook.io",
                client_key="test-key",
                sticky_bucket_service=service,
+               **opt_kwargs,
            )
 
 
@@ -940,6 +941,50 @@ async def test_sticky_bucket_distinct_users_fetch_in_parallel():
             assert service.get_all_calls == 3
             fetch_gate.set()
             await asyncio.gather(*tasks)
+
+
+@pytest.mark.asyncio
+async def test_sticky_bucket_opt_in_ttl_cache():
+    """With sticky_bucket_cache_ttl > 0, fetched assignments are reused per
+    attributes dict (bounded staleness), LRU-bounded by
+    sticky_bucket_cache_size."""
+    service = AsyncInMemoryStickyBucketService()
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(
+        service, sticky_bucket_cache_ttl=60, sticky_bucket_cache_size=2)
+
+    async def ev(uid):
+        await client.eval_feature("read-feature", UserContext(attributes={"id": uid}))
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            await ev("user-1")
+            await ev("user-1")
+            assert service.get_all_calls == 1  # cached
+            await ev("user-2")
+            await ev("user-3")  # evicts user-1 (size bound = 2)
+            assert service.get_all_calls == 3
+            await ev("user-2")  # still cached
+            assert service.get_all_calls == 3
+            await ev("user-1")  # was evicted -> refetch
+            assert service.get_all_calls == 4
+
+
+@pytest.mark.asyncio
+async def test_sticky_bucket_nonpositive_cache_size_disables_caching():
+    """Regression: sticky_bucket_cache_size=-1 used to crash evaluation with
+    KeyError (popitem on an empty cache). Non-positive size (or ttl) now
+    simply disables caching."""
+    service = AsyncInMemoryStickyBucketService()
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(
+        service, sticky_bucket_cache_ttl=60, sticky_bucket_cache_size=-1)
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            await client.eval_feature("read-feature", UserContext(attributes={"id": "user-1"}))
+            await client.eval_feature("read-feature", UserContext(attributes={"id": "user-2"}))
+    assert service.get_all_calls == 2  # no crash; per-eval fetch
 
 
 @pytest.mark.asyncio

--- a/tests/test_growthbook_client.py
+++ b/tests/test_growthbook_client.py
@@ -913,6 +913,34 @@ async def test_sticky_bucket_cache_invalidated_on_attribute_change():
             assert service.get_all_calls == 2  # attribute change -> refetch
 
 
+@pytest.mark.asyncio
+async def test_feature_update_swaps_snapshot_without_disrupting_eval():
+    """A feature update mid-evaluation must not affect the in-flight eval
+    (it finishes against the snapshot it captured) and must be visible to
+    the next eval — lock-free consistency via immutable snapshot swap."""
+    fetch_gate = asyncio.Event()
+    service = AsyncInMemoryStickyBucketService(fetch_gate=fetch_gate)
+    EnhancedFeatureRepository._instances = {}
+    p1, p2, p3, opts = _sticky_client_ctx(service)
+
+    with p1, p2, p3:
+        async with GrowthBookClient(opts) as client:
+            inflight = asyncio.ensure_future(
+                client.eval_feature("read-feature", UserContext(attributes={"id": "user-1"}))
+            )
+            for _ in range(5):
+                await asyncio.sleep(0)
+            # Swap features while the first eval is parked on the sticky fetch
+            await client.set_features({"read-feature": {"defaultValue": "v2"}})
+            fetch_gate.set()
+
+            result = await inflight
+            assert result.value == "control"  # finished against its captured snapshot
+
+            result2 = await client.eval_feature("read-feature", UserContext(attributes={"id": "user-1"}))
+            assert result2.value == "v2"  # new snapshot visible to the next eval
+
+
 # Experiment forcing variation1 (weights [0, 1]) so a sticky bucket
 # assignment doc is written deterministically on first evaluation.
 STICKY_WRITE_FEATURES = {

--- a/tests/test_growthbook_client.py
+++ b/tests/test_growthbook_client.py
@@ -1162,6 +1162,52 @@ async def test_async_user_callbacks_are_scheduled_and_drained():
         assert "manual-exp" in subs
 
 
+@pytest.mark.asyncio
+async def test_failed_async_tracking_callback_is_retried():
+    """An async on_experiment_viewed that fails must be un-deduped so the
+    impression fires again on the next eval (parity with sync callbacks,
+    whose exceptions also leave the event unmarked)."""
+    calls = []
+
+    async def flaky_tracker(experiment, result, user_context):
+        calls.append(experiment.key)
+        if len(calls) == 1:
+            raise RuntimeError("collector down")
+
+    EnhancedFeatureRepository._instances = {}
+    opts = Options(
+        api_host="https://localhost.growthbook.io",
+        client_key="test-key",
+        on_experiment_viewed=flaky_tracker,
+    )
+
+    with patch('growthbook.FeatureRepository.load_features_async',
+               new_callable=AsyncMock, return_value=STICKY_WRITE_FEATURES), \
+         patch('growthbook.growthbook_client.EnhancedFeatureRepository.start_feature_refresh',
+               new_callable=AsyncMock), \
+         patch('growthbook.growthbook_client.EnhancedFeatureRepository.stop_refresh',
+               new_callable=AsyncMock):
+        async with GrowthBookClient(opts) as client:
+            user = UserContext(attributes={"id": "user-1"})
+
+            await client.eval_feature("exp-feature", user)
+            while client._callback_tasks:  # let the failing callback settle
+                await asyncio.gather(*list(client._callback_tasks), return_exceptions=True)
+            assert calls == ["exp"]
+
+            # First attempt failed -> retried on the next eval
+            await client.eval_feature("exp-feature", user)
+            while client._callback_tasks:
+                await asyncio.gather(*list(client._callback_tasks), return_exceptions=True)
+            assert calls == ["exp", "exp"]
+
+            # Second attempt succeeded -> now deduped
+            await client.eval_feature("exp-feature", user)
+            while client._callback_tasks:
+                await asyncio.gather(*list(client._callback_tasks), return_exceptions=True)
+            assert calls == ["exp", "exp"]
+
+
 async def getTrackingMock(client: GrowthBookClient):
     """Helper function to mock tracking for tests"""
     calls = []


### PR DESCRIPTION
Follow-up to #128 (stacked on its branch). Branch was rebuilt after external review; see the findings comment on #127.

## Summary

Removes the eval-wide lock, makes concurrent sticky-bucket fetching cancellation-safe, and replaces the originally-proposed indefinite LRU cache with JS-parity per-eval fetching plus an explicit opt-in TTL cache. Also fixes the async-tracking retry asymmetry. Net effect on the checked-in benchmark: distinct-user throughput with an async sticky service goes from ~342 rps to ~19,900 rps (~58x) with p50 request latency dropping from 310 ms to 4.3 ms — with bounded (or zero) staleness, unlike the earlier unbounded-cache draft.

## What's included

- **Lock-free evaluation via immutable snapshot swap** — `_eval_lock` (the shared `_context_lock`) serialized every CDN-mode evaluation, including across the sticky prefetch await. `_feature_update_callback` now builds a NEW `GlobalContext` and swaps the reference atomically; each evaluation captures the current snapshot once and runs without locks:

  ```python
  # before (every eval, CDN mode)
  async with self._eval_lock():
      context = await self.create_evaluation_context(user_context)
      result = core_eval_feature(...)

  # after
  context = await self.create_evaluation_context(user_context)   # captures snapshot ref
  result = core_eval_feature(...)
  ```

  In-flight evaluations finish against their captured snapshot; the next evaluation sees the new one (tested by swapping features mid-eval).

- **Cancellation-safe per-key coalesced sticky fetch** — concurrent evals with identical attributes share one inflight fetch; distinct attributes fetch in parallel (previously a single global lock serialized all fetches). Waiters await `asyncio.shield(inflight)`: a cancelled waiter can no longer propagate its cancellation into the shared future (which made the OWNER's successful fetch die with `InvalidStateError` — reproduced, now regression-tested). Owner cancellation semantics are defined: the shared future is cancelled and waiters retry, one becoming the new owner (also tested).

  ```python
  # waiter side
  try:
      return await asyncio.shield(inflight)
  except asyncio.CancelledError:
      if not inflight.cancelled():
          raise          # we were cancelled; owner fetch continues
      continue           # owner was cancelled; retry, maybe become owner
  ```

- **Cache policy: per-eval fetch by default, opt-in TTL cache** — the earlier draft of this PR cached fetched assignments indefinitely per attributes dict (LRU-bounded), which meant assignments written by another worker could stay invisible forever in a low-cardinality service, and its claimed JS parity was wrong: the JS SDK's server-side [`GrowthBookClient.applyStickyBuckets`](https://github.com/growthbook/growthbook/blob/main/packages/sdk-js/src/GrowthBookClient.ts) fetches assignments fresh for each supplied context. Default behavior now matches that: every evaluation fetches (coalesced when concurrent), so cross-worker writes are visible on the next eval. For deployments that prefer fewer service round-trips, `Options.sticky_bucket_cache_ttl` (seconds, default 0 = disabled) enables a bounded-staleness cache, LRU-limited by `Options.sticky_bucket_cache_size`; cache hits still re-apply this process's own writes from #128's authoritative doc map.

- **Validated cache sizing** — `sticky_bucket_cache_size <= 0` (or `ttl <= 0`) now cleanly disables caching; previously a negative size crashed evaluation with `KeyError` from `popitem()` on an empty cache (reproduced, regression-tested). This matches the existing `remote_eval_cache_size` convention (negative = cache holds nothing).

- **Async tracking callbacks retried on failure** — #128 marked an experiment as tracked when the async `on_experiment_viewed` coroutine was scheduled; if it later failed, the impression was lost forever (a failing sync callback is retried on the next eval). The dedup key is now un-marked when the scheduled coroutine fails, restoring parity.

## Measured impact (tests/scripts/benchmark_async_client.py, 100-way concurrency, 1000 requests, 1 ms service latency, default cache-off policy)

| Scenario | #128 | This PR | Change |
|---|---|---|---|
| async sticky service, distinct users | 342 rps / p50 310 ms | 19,874 rps / p50 4.3 ms | ~58x |
| sync sticky service, distinct users | 303 rps / p50 333 ms | 3,051 rps / p50 32 ms | ~10x |
| async service, hot user | 18,059 rps | 31,306 rps | ~1.7x |
| no sticky service (control) | ~55,000 rps | ~67,500 rps | lock removal |

Event-loop lag stays sub-7 ms in every scenario. The gains come from removing the locks and parallelizing fetches — NOT from caching (these numbers are with the cache disabled). The remaining sync-vs-async gap (3k vs 19.9k rps) is the default executor's thread-pool ceiling — the concrete case for implementing `AbstractAsyncStickyBucketService` on network-backed stores.

## Behavior notes for review

- Default sticky fetch volume increases vs #128 (one service call per evaluation instead of single-slot caching). This is the JS-parity correctness choice; the TTL cache is the explicit opt-out. A batched `get_all_assignments` override (single Redis MGET) keeps the per-eval cost to one round-trip.
- With the TTL cache enabled, cross-worker writes are masked for at most `sticky_bucket_cache_ttl` seconds — bounded, documented staleness rather than the earlier draft's indefinite masking.

## Test plan

- [x] Full suite: `pytest tests/ -q --ignore=tests/scripts` — 816 passed (809 in #128 + 7 new)
- [x] Cancellation both directions: cancelled waiter → owner completes normally; cancelled owner → waiter retries and succeeds
- [x] Distinct users' fetches provably overlap (gated-fetch test that fails under any global lock)
- [x] Feature update mid-eval: in-flight eval finishes on its captured snapshot; next eval sees the update
- [x] Per-eval fetch default; TTL cache opt-in hit/LRU-eviction; non-positive size/ttl disables caching without crashing
- [x] Failed async tracking callback retried on next eval, deduped after success
- [x] External reviewer's probes re-run against this branch: lost-update NO LOSS, waiter-cancel NOT REPRODUCED, negative-size NOT REPRODUCED
- [x] `mypy growthbook/growthbook*.py tests/typing_probe.py --implicit-optional` — clean

## Out of scope (deliberately)

- Dedicated bounded executor pool for sync services (the 3k rps ceiling above); revisit on demand.
- Save retry policy for failed sticky writes (still log-only, matching JS).
