### PR TITLE
Sync conformance corpus with JS SDK 0.8.0

### DIFF
--- a/tests/cases.json
+++ b/tests/cases.json
@@ -63,24 +63,32 @@
         "$and": [
           {
             "$groups": {
-              "$elemMatch": { "$eq": "a" }
+              "$elemMatch": {
+                "$eq": "a"
+              }
             }
           },
           {
             "$groups": {
-              "$elemMatch": { "$eq": "b" }
+              "$elemMatch": {
+                "$eq": "b"
+              }
             }
           },
           {
             "$or": [
               {
                 "$groups": {
-                  "$elemMatch": { "$eq": "c" }
+                  "$elemMatch": {
+                    "$eq": "c"
+                  }
                 }
               },
               {
                 "$groups": {
-                  "$elemMatch": { "$eq": "e" }
+                  "$elemMatch": {
+                    "$eq": "e"
+                  }
                 }
               }
             ]
@@ -88,21 +96,30 @@
           {
             "$not": {
               "$groups": {
-                "$elemMatch": { "$eq": "f" }
+                "$elemMatch": {
+                  "$eq": "f"
+                }
               }
             }
           },
           {
             "$not": {
               "$groups": {
-                "$elemMatch": { "$eq": "g" }
+                "$elemMatch": {
+                  "$eq": "g"
+                }
               }
             }
           }
         ]
       },
       {
-        "$groups": ["a", "b", "c", "d"]
+        "$groups": [
+          "a",
+          "b",
+          "c",
+          "d"
+        ]
       },
       true
     ],
@@ -112,24 +129,32 @@
         "$and": [
           {
             "$groups": {
-              "$elemMatch": { "$eq": "a" }
+              "$elemMatch": {
+                "$eq": "a"
+              }
             }
           },
           {
             "$groups": {
-              "$elemMatch": { "$eq": "b" }
+              "$elemMatch": {
+                "$eq": "b"
+              }
             }
           },
           {
             "$or": [
               {
                 "$groups": {
-                  "$elemMatch": { "$eq": "c" }
+                  "$elemMatch": {
+                    "$eq": "c"
+                  }
                 }
               },
               {
                 "$groups": {
-                  "$elemMatch": { "$eq": "e" }
+                  "$elemMatch": {
+                    "$eq": "e"
+                  }
                 }
               }
             ]
@@ -137,21 +162,30 @@
           {
             "$not": {
               "$groups": {
-                "$elemMatch": { "$eq": "d" }
+                "$elemMatch": {
+                  "$eq": "d"
+                }
               }
             }
           },
           {
             "$not": {
               "$groups": {
-                "$elemMatch": { "$eq": "g" }
+                "$elemMatch": {
+                  "$eq": "g"
+                }
               }
             }
           }
         ]
       },
       {
-        "$groups": ["a", "b", "c", "d"]
+        "$groups": [
+          "a",
+          "b",
+          "c",
+          "d"
+        ]
       },
       false
     ],
@@ -389,7 +423,11 @@
       "$in - pass",
       {
         "num": {
-          "$in": [1, 2, 3]
+          "$in": [
+            1,
+            2,
+            3
+          ]
         }
       },
       {
@@ -401,7 +439,11 @@
       "$in - fail",
       {
         "num": {
-          "$in": [1, 2, 3]
+          "$in": [
+            1,
+            2,
+            3
+          ]
         }
       },
       {
@@ -425,11 +467,18 @@
       "$in - array pass 1",
       {
         "tags": {
-          "$in": ["a", "b"]
+          "$in": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "e", "a"]
+        "tags": [
+          "d",
+          "e",
+          "a"
+        ]
       },
       true
     ],
@@ -437,11 +486,18 @@
       "$in - array pass 2",
       {
         "tags": {
-          "$in": ["a", "b"]
+          "$in": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "b", "f"]
+        "tags": [
+          "d",
+          "b",
+          "f"
+        ]
       },
       true
     ],
@@ -449,11 +505,18 @@
       "$in - array pass 3",
       {
         "tags": {
-          "$in": ["a", "b"]
+          "$in": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "b", "a"]
+        "tags": [
+          "d",
+          "b",
+          "a"
+        ]
       },
       true
     ],
@@ -461,11 +524,18 @@
       "$in - array fail 1",
       {
         "tags": {
-          "$in": ["a", "b"]
+          "$in": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "e", "f"]
+        "tags": [
+          "d",
+          "e",
+          "f"
+        ]
       },
       false
     ],
@@ -473,7 +543,10 @@
       "$in - array fail 2",
       {
         "tags": {
-          "$in": ["a", "b"]
+          "$in": [
+            "a",
+            "b"
+          ]
         }
       },
       {
@@ -485,7 +558,11 @@
       "$nin - pass",
       {
         "num": {
-          "$nin": [1, 2, 3]
+          "$nin": [
+            1,
+            2,
+            3
+          ]
         }
       },
       {
@@ -497,7 +574,11 @@
       "$nin - fail",
       {
         "num": {
-          "$nin": [1, 2, 3]
+          "$nin": [
+            1,
+            2,
+            3
+          ]
         }
       },
       {
@@ -521,11 +602,18 @@
       "$nin - array fail 1",
       {
         "tags": {
-          "$nin": ["a", "b"]
+          "$nin": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "e", "a"]
+        "tags": [
+          "d",
+          "e",
+          "a"
+        ]
       },
       false
     ],
@@ -533,11 +621,18 @@
       "$nin - array fail 2",
       {
         "tags": {
-          "$nin": ["a", "b"]
+          "$nin": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "b", "f"]
+        "tags": [
+          "d",
+          "b",
+          "f"
+        ]
       },
       false
     ],
@@ -545,11 +640,18 @@
       "$nin - array fail 3",
       {
         "tags": {
-          "$nin": ["a", "b"]
+          "$nin": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "b", "a"]
+        "tags": [
+          "d",
+          "b",
+          "a"
+        ]
       },
       false
     ],
@@ -557,11 +659,18 @@
       "$nin - array pass 1",
       {
         "tags": {
-          "$nin": ["a", "b"]
+          "$nin": [
+            "a",
+            "b"
+          ]
         }
       },
       {
-        "tags": ["d", "e", "f"]
+        "tags": [
+          "d",
+          "e",
+          "f"
+        ]
       },
       true
     ],
@@ -569,7 +678,10 @@
       "$nin - array pass 2",
       {
         "tags": {
-          "$nin": ["a", "b"]
+          "$nin": [
+            "a",
+            "b"
+          ]
         }
       },
       {
@@ -587,7 +699,12 @@
         }
       },
       {
-        "nums": [0, 5, -20, 15]
+        "nums": [
+          0,
+          5,
+          -20,
+          15
+        ]
       },
       true
     ],
@@ -601,7 +718,12 @@
         }
       },
       {
-        "nums": [0, 5, -20, 8]
+        "nums": [
+          0,
+          5,
+          -20,
+          8
+        ]
       },
       false
     ],
@@ -609,7 +731,9 @@
       "missing attribute - fail",
       {
         "pets.dog.name": {
-          "$in": ["fido"]
+          "$in": [
+            "fido"
+          ]
         }
       },
       {
@@ -633,25 +757,43 @@
     ],
     [
       "$ne string vs missing attribute",
-      { "country": { "$ne": "de" } },
+      {
+        "country": {
+          "$ne": "de"
+        }
+      },
       {},
       true
     ],
     [
       "$ne string vs explicit None attribute",
-      { "country": { "$ne": "de" } },
-      { "country": null },
+      {
+        "country": {
+          "$ne": "de"
+        }
+      },
+      {
+        "country": null
+      },
       true
     ],
     [
       "$notRegex vs missing attribute",
-      { "name": { "$notRegex": "abc" } },
+      {
+        "name": {
+          "$notRegex": "abc"
+        }
+      },
       {},
       true
     ],
     [
       "$notRegexi vs missing attribute",
-      { "name": { "$notRegexi": "ABC" } },
+      {
+        "name": {
+          "$notRegexi": "ABC"
+        }
+      },
       {},
       true
     ],
@@ -869,7 +1011,10 @@
       "$ini - pass",
       {
         "tags": {
-          "$ini": ["A", "B"]
+          "$ini": [
+            "A",
+            "B"
+          ]
         }
       },
       {
@@ -881,7 +1026,10 @@
       "$ini - fail",
       {
         "tags": {
-          "$ini": ["a", "b"]
+          "$ini": [
+            "a",
+            "b"
+          ]
         }
       },
       {
@@ -893,11 +1041,17 @@
       "$ini - array pass",
       {
         "tags": {
-          "$ini": ["A", "B"]
+          "$ini": [
+            "A",
+            "B"
+          ]
         }
       },
       {
-        "tags": ["d", "a"]
+        "tags": [
+          "d",
+          "a"
+        ]
       },
       true
     ],
@@ -905,7 +1059,10 @@
       "$nini - pass",
       {
         "tags": {
-          "$nini": ["A", "B"]
+          "$nini": [
+            "A",
+            "B"
+          ]
         }
       },
       {
@@ -917,7 +1074,10 @@
       "$nini - fail",
       {
         "tags": {
-          "$nini": ["A", "B"]
+          "$nini": [
+            "A",
+            "B"
+          ]
         }
       },
       {
@@ -929,11 +1089,18 @@
       "$alli - pass",
       {
         "tags": {
-          "$alli": ["A", "B"]
+          "$alli": [
+            "A",
+            "B"
+          ]
         }
       },
       {
-        "tags": ["a", "b", "c"]
+        "tags": [
+          "a",
+          "b",
+          "c"
+        ]
       },
       true
     ],
@@ -941,11 +1108,17 @@
       "$alli - fail",
       {
         "tags": {
-          "$alli": ["A", "B"]
+          "$alli": [
+            "A",
+            "B"
+          ]
         }
       },
       {
-        "tags": ["a", "c"]
+        "tags": [
+          "a",
+          "c"
+        ]
       },
       false
     ],
@@ -1255,7 +1428,10 @@
         }
       },
       {
-        "a": [1, 2]
+        "a": [
+          1,
+          2
+        ]
       },
       true
     ],
@@ -1310,7 +1486,9 @@
     [
       "$size empty - pass",
       {
-        "tags": { "$size": 0 }
+        "tags": {
+          "$size": 0
+        }
       },
       {
         "tags": []
@@ -1320,10 +1498,14 @@
     [
       "$size empty - fail",
       {
-        "tags": { "$size": 0 }
+        "tags": {
+          "$size": 0
+        }
       },
       {
-        "tags": [10]
+        "tags": [
+          10
+        ]
       },
       false
     ],
@@ -1335,7 +1517,11 @@
         }
       },
       {
-        "tags": ["a", "b", "c"]
+        "tags": [
+          "a",
+          "b",
+          "c"
+        ]
       },
       true
     ],
@@ -1347,7 +1533,10 @@
         }
       },
       {
-        "tags": ["a", "b"]
+        "tags": [
+          "a",
+          "b"
+        ]
       },
       false
     ],
@@ -1359,7 +1548,12 @@
         }
       },
       {
-        "tags": ["a", "b", "c", "d"]
+        "tags": [
+          "a",
+          "b",
+          "c",
+          "d"
+        ]
       },
       false
     ],
@@ -1385,7 +1579,11 @@
         }
       },
       {
-        "tags": [0, 1, 2]
+        "tags": [
+          0,
+          1,
+          2
+        ]
       },
       true
     ],
@@ -1399,7 +1597,10 @@
         }
       },
       {
-        "tags": [0, 1]
+        "tags": [
+          0,
+          1
+        ]
       },
       false
     ],
@@ -1413,7 +1614,9 @@
         }
       },
       {
-        "tags": [0]
+        "tags": [
+          0
+        ]
       },
       false
     ],
@@ -1427,7 +1630,11 @@
         }
       },
       {
-        "tags": ["foo", "bar", "baz"]
+        "tags": [
+          "foo",
+          "bar",
+          "baz"
+        ]
       },
       true
     ],
@@ -1441,7 +1648,10 @@
         }
       },
       {
-        "tags": ["foo", "baz"]
+        "tags": [
+          "foo",
+          "baz"
+        ]
       },
       false
     ],
@@ -1450,12 +1660,19 @@
       {
         "tags": {
           "$elemMatch": {
-            "$in": ["a", "b"]
+            "$in": [
+              "a",
+              "b"
+            ]
           }
         }
       },
       {
-        "tags": ["d", "e", "b"]
+        "tags": [
+          "d",
+          "e",
+          "b"
+        ]
       },
       true
     ],
@@ -1464,12 +1681,19 @@
       {
         "tags": {
           "$elemMatch": {
-            "$in": ["a", "b"]
+            "$in": [
+              "a",
+              "b"
+            ]
           }
         }
       },
       {
-        "tags": ["d", "e", "f"]
+        "tags": [
+          "d",
+          "e",
+          "f"
+        ]
       },
       false
     ],
@@ -1485,7 +1709,10 @@
         }
       },
       {
-        "tags": ["foo", "baz"]
+        "tags": [
+          "foo",
+          "baz"
+        ]
       },
       true
     ],
@@ -1501,7 +1728,11 @@
         }
       },
       {
-        "tags": ["foo", "bar", "baz"]
+        "tags": [
+          "foo",
+          "bar",
+          "baz"
+        ]
       },
       false
     ],
@@ -1602,11 +1833,18 @@
       "$all - pass",
       {
         "tags": {
-          "$all": ["one", "three"]
+          "$all": [
+            "one",
+            "three"
+          ]
         }
       },
       {
-        "tags": ["one", "two", "three"]
+        "tags": [
+          "one",
+          "two",
+          "three"
+        ]
       },
       true
     ],
@@ -1614,11 +1852,18 @@
       "$all - fail",
       {
         "tags": {
-          "$all": ["one", "three"]
+          "$all": [
+            "one",
+            "three"
+          ]
         }
       },
       {
-        "tags": ["one", "two", "four"]
+        "tags": [
+          "one",
+          "two",
+          "four"
+        ]
       },
       false
     ],
@@ -1626,7 +1871,10 @@
       "$all - fail not array",
       {
         "tags": {
-          "$all": ["one", "three"]
+          "$all": [
+            "one",
+            "three"
+          ]
         }
       },
       {
@@ -1717,47 +1965,74 @@
     [
       "equals array - pass",
       {
-        "tags": ["hello", "world"]
+        "tags": [
+          "hello",
+          "world"
+        ]
       },
       {
-        "tags": ["hello", "world"]
+        "tags": [
+          "hello",
+          "world"
+        ]
       },
       true
     ],
     [
       "equals array - fail order",
       {
-        "tags": ["hello", "world"]
+        "tags": [
+          "hello",
+          "world"
+        ]
       },
       {
-        "tags": ["world", "hello"]
+        "tags": [
+          "world",
+          "hello"
+        ]
       },
       false
     ],
     [
       "equals array - fail missing item",
       {
-        "tags": ["hello", "world"]
+        "tags": [
+          "hello",
+          "world"
+        ]
       },
       {
-        "tags": ["hello"]
+        "tags": [
+          "hello"
+        ]
       },
       false
     ],
     [
       "equals array - fail extra item",
       {
-        "tags": ["hello", "world"]
+        "tags": [
+          "hello",
+          "world"
+        ]
       },
       {
-        "tags": ["hello", "world", "foo"]
+        "tags": [
+          "hello",
+          "world",
+          "foo"
+        ]
       },
       false
     ],
     [
       "equals array - fail type mismatch",
       {
-        "tags": ["hello", "world"]
+        "tags": [
+          "hello",
+          "world"
+        ]
       },
       {
         "tags": "hello world"
@@ -1886,7 +2161,9 @@
     [
       "false strict condition - missing attribute",
       {
-        "userId": { "$eq": false }
+        "userId": {
+          "$eq": false
+        }
       },
       {},
       false
@@ -2997,7 +3274,14 @@
     [
       "$or pass but second condition fail",
       {
-        "$or": [{ "foo": 1 }, { "bar": 1 }],
+        "$or": [
+          {
+            "foo": 1
+          },
+          {
+            "bar": 1
+          }
+        ],
         "baz": 2
       },
       {
@@ -3010,7 +3294,14 @@
     [
       "$or and second condition both pass",
       {
-        "$or": [{ "foo": 1 }, { "bar": 1 }],
+        "$or": [
+          {
+            "foo": 1
+          },
+          {
+            "bar": 1
+          }
+        ],
         "baz": 2
       },
       {
@@ -3023,8 +3314,22 @@
     [
       "$and condition pass but $or fail",
       {
-        "$and": [{ "foo": 1 }, { "bar": 1 }],
-        "$or": [{ "baz": 1 }, { "empty": 1 }]
+        "$and": [
+          {
+            "foo": 1
+          },
+          {
+            "bar": 1
+          }
+        ],
+        "$or": [
+          {
+            "baz": 1
+          },
+          {
+            "empty": 1
+          }
+        ]
       },
       {
         "foo": 1,
@@ -3036,8 +3341,22 @@
     [
       "$and and $or both pass",
       {
-        "$and": [{ "foo": 1 }, { "bar": 1 }],
-        "$or": [{ "baz": 1 }, { "empty": 1 }]
+        "$and": [
+          {
+            "foo": 1
+          },
+          {
+            "bar": 1
+          }
+        ],
+        "$or": [
+          {
+            "baz": 1
+          },
+          {
+            "empty": 1
+          }
+        ]
       },
       {
         "foo": 1,
@@ -3050,74 +3369,154 @@
     [
       "$inGroup passes for member of known group id",
       {
-        "id": { "$inGroup": "group_id" }
+        "id": {
+          "$inGroup": "group_id"
+        }
       },
-      { "id": 1 },
+      {
+        "id": 1
+      },
       true,
-      { "group_id": [1, 2, 3] }
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
     ],
     [
       "$inGroup fails for non-member of known group id",
       {
-        "id": { "$inGroup": "group_id" }
+        "id": {
+          "$inGroup": "group_id"
+        }
       },
-      { "id": 5 },
+      {
+        "id": 5
+      },
       false,
-      { "group_id": [1, 2, 3] }
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
     ],
     [
       "$inGroup fails for unknown group id",
       {
-        "id": { "$inGroup": "unknowngroup_id" }
+        "id": {
+          "$inGroup": "unknowngroup_id"
+        }
       },
-      { "id": 1 },
+      {
+        "id": 1
+      },
       false,
-      { "group_id": [1, 2, 3] }
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
     ],
     [
       "$notInGroup fails for member of known group id",
       {
-        "id": { "$notInGroup": "group_id" }
+        "id": {
+          "$notInGroup": "group_id"
+        }
       },
-      { "id": 1 },
+      {
+        "id": 1
+      },
       false,
-      { "group_id": [1, 2, 3] }
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
     ],
     [
       "$notInGroup passes for non-member of known group id",
       {
-        "id": { "$notInGroup": "group_id" }
+        "id": {
+          "$notInGroup": "group_id"
+        }
       },
-      { "id": 5 },
+      {
+        "id": 5
+      },
       true,
-      { "group_id": [1, 2, 3] }
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
     ],
     [
       "$notInGroup passes for unknown group id",
       {
-        "id": { "$notInGroup": "unknowngroup_id" }
+        "id": {
+          "$notInGroup": "unknowngroup_id"
+        }
       },
-      { "id": 1 },
+      {
+        "id": 1
+      },
       true,
-      { "group_id": [1, 2, 3] }
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
     ],
     [
       "$inGroup passes for properly typed data",
       {
-        "id": { "$inGroup": "group_id" }
+        "id": {
+          "$inGroup": "group_id"
+        }
       },
-      { "id": "2" },
+      {
+        "id": "2"
+      },
       true,
-      { "group_id": [1, "2", 3] }
+      {
+        "group_id": [
+          1,
+          "2",
+          3
+        ]
+      }
     ],
     [
       "$inGroup fails for improperly typed data",
       {
-        "id": { "$inGroup": "group_id" }
+        "id": {
+          "$inGroup": "group_id"
+        }
       },
-      { "id": "3" },
+      {
+        "id": "3"
+      },
       false,
-      { "group_id": [1, "2", 3] }
+      {
+        "group_id": [
+          1,
+          "2",
+          3
+        ]
+      }
     ],
     [
       "$in - fail (case sensitive mismatch)",
@@ -3708,11 +4107,19 @@
       "[D6c] $eq array literal vs equal array literal is strict-identity false (JS === for containers)",
       {
         "x": {
-          "$eq": [1, 2, 3]
+          "$eq": [
+            1,
+            2,
+            3
+          ]
         }
       },
       {
-        "x": [1, 2, 3]
+        "x": [
+          1,
+          2,
+          3
+        ]
       },
       false
     ],
@@ -3720,11 +4127,17 @@
       "[D6c] $eq object literal vs equal object literal is strict-identity false (JS === for containers)",
       {
         "x": {
-          "$eq": {"a": 1, "b": 2}
+          "$eq": {
+            "a": 1,
+            "b": 2
+          }
         }
       },
       {
-        "x": {"a": 1, "b": 2}
+        "x": {
+          "a": 1,
+          "b": 2
+        }
       },
       false
     ],
@@ -3732,141 +4145,396 @@
       "[D6c] $ne array literal vs equal array literal is true (negation of strict-identity)",
       {
         "x": {
-          "$ne": [1, 2, 3]
+          "$ne": [
+            1,
+            2,
+            3
+          ]
         }
       },
       {
-        "x": [1, 2, 3]
+        "x": [
+          1,
+          2,
+          3
+        ]
       },
       true
     ]
   ],
   "hash": [
-    ["", "a", 1, 0.22],
-    ["", "b", 1, 0.077],
-    ["b", "a", 1, 0.946],
-    ["ef", "d", 1, 0.652],
-    ["asdf", "8952klfjas09ujk", 1, 0.549],
-    ["", "123", 1, 0.011],
-    ["", "___)((*\":&", 1, 0.563],
-    ["seed", "a", 2, 0.0505],
-    ["seed", "b", 2, 0.2696],
-    ["foo", "ab", 2, 0.2575],
-    ["foo", "def", 2, 0.2019],
-    ["89123klj", "8952klfjas09ujkasdf", 2, 0.124],
-    ["90850943850283058242805", "123", 2, 0.7516],
-    ["()**(%$##$%#$#", "___)((*\":&", 2, 0.0128],
-    ["abc", "def", 99, null]
+    [
+      "",
+      "a",
+      1,
+      0.22
+    ],
+    [
+      "",
+      "b",
+      1,
+      0.077
+    ],
+    [
+      "b",
+      "a",
+      1,
+      0.946
+    ],
+    [
+      "ef",
+      "d",
+      1,
+      0.652
+    ],
+    [
+      "asdf",
+      "8952klfjas09ujk",
+      1,
+      0.549
+    ],
+    [
+      "",
+      "123",
+      1,
+      0.011
+    ],
+    [
+      "",
+      "___)((*\":&",
+      1,
+      0.563
+    ],
+    [
+      "seed",
+      "a",
+      2,
+      0.0505
+    ],
+    [
+      "seed",
+      "b",
+      2,
+      0.2696
+    ],
+    [
+      "foo",
+      "ab",
+      2,
+      0.2575
+    ],
+    [
+      "foo",
+      "def",
+      2,
+      0.2019
+    ],
+    [
+      "89123klj",
+      "8952klfjas09ujkasdf",
+      2,
+      0.124
+    ],
+    [
+      "90850943850283058242805",
+      "123",
+      2,
+      0.7516
+    ],
+    [
+      "()**(%$##$%#$#",
+      "___)((*\":&",
+      2,
+      0.0128
+    ],
+    [
+      "abc",
+      "def",
+      99,
+      null
+    ]
   ],
   "getBucketRange": [
     [
       "normal 50/50",
-      [2, 1, null],
       [
-        [0, 0.5],
-        [0.5, 1]
+        2,
+        1,
+        null
+      ],
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ]
     ],
     [
       "reduced coverage",
-      [2, 0.5, null],
       [
-        [0, 0.25],
-        [0.5, 0.75]
+        2,
+        0.5,
+        null
+      ],
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
       ]
     ],
     [
       "zero coverage",
-      [2, 0, null],
       [
-        [0, 0],
-        [0.5, 0.5]
+        2,
+        0,
+        null
+      ],
+      [
+        [
+          0,
+          0
+        ],
+        [
+          0.5,
+          0.5
+        ]
       ]
     ],
     [
       "4 variations",
-      [4, 1, null],
       [
-        [0, 0.25],
-        [0.25, 0.5],
-        [0.5, 0.75],
-        [0.75, 1]
+        4,
+        1,
+        null
+      ],
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.25,
+          0.5
+        ],
+        [
+          0.5,
+          0.75
+        ],
+        [
+          0.75,
+          1
+        ]
       ]
     ],
     [
       "uneven weights",
-      [2, 1, [0.4, 0.6]],
       [
-        [0, 0.4],
-        [0.4, 1]
+        2,
+        1,
+        [
+          0.4,
+          0.6
+        ]
+      ],
+      [
+        [
+          0,
+          0.4
+        ],
+        [
+          0.4,
+          1
+        ]
       ]
     ],
     [
       "uneven weights, 3 variations",
-      [3, 1, [0.2, 0.3, 0.5]],
       [
-        [0, 0.2],
-        [0.2, 0.5],
-        [0.5, 1]
+        3,
+        1,
+        [
+          0.2,
+          0.3,
+          0.5
+        ]
+      ],
+      [
+        [
+          0,
+          0.2
+        ],
+        [
+          0.2,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ]
     ],
     [
       "uneven weights, reduced coverage, 3 variations",
-      [3, 0.2, [0.2, 0.3, 0.5]],
       [
-        [0, 0.04],
-        [0.2, 0.26],
-        [0.5, 0.6]
+        3,
+        0.2,
+        [
+          0.2,
+          0.3,
+          0.5
+        ]
+      ],
+      [
+        [
+          0,
+          0.04
+        ],
+        [
+          0.2,
+          0.26
+        ],
+        [
+          0.5,
+          0.6
+        ]
       ]
     ],
     [
       "negative coverage",
-      [2, -0.2, null],
       [
-        [0, 0],
-        [0.5, 0.5]
+        2,
+        -0.2,
+        null
+      ],
+      [
+        [
+          0,
+          0
+        ],
+        [
+          0.5,
+          0.5
+        ]
       ]
     ],
     [
       "coverage above 1",
-      [2, 1.5, null],
       [
-        [0, 0.5],
-        [0.5, 1]
+        2,
+        1.5,
+        null
+      ],
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ]
     ],
     [
       "weights sum below 1",
-      [2, 1, [0.4, 0.1]],
       [
-        [0, 0.5],
-        [0.5, 1]
+        2,
+        1,
+        [
+          0.4,
+          0.1
+        ]
+      ],
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ]
     ],
     [
       "weights sum above 1",
-      [2, 1, [0.7, 0.6]],
       [
-        [0, 0.5],
-        [0.5, 1]
+        2,
+        1,
+        [
+          0.7,
+          0.6
+        ]
+      ],
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ]
     ],
     [
       "weights.length not equal to num variations",
-      [4, 1, [0.4, 0.4, 0.2]],
       [
-        [0, 0.25],
-        [0.25, 0.5],
-        [0.5, 0.75],
-        [0.75, 1]
+        4,
+        1,
+        [
+          0.4,
+          0.4,
+          0.2
+        ]
+      ],
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.25,
+          0.5
+        ],
+        [
+          0.5,
+          0.75
+        ],
+        [
+          0.75,
+          1
+        ]
       ]
     ],
     [
       "weights sum almost equals 1",
-      [2, 1, [0.4, 0.5999]],
       [
-        [0, 0.4],
-        [0.4, 0.9999]
+        2,
+        1,
+        [
+          0.4,
+          0.5999
+        ]
+      ],
+      [
+        [
+          0,
+          0.4
+        ],
+        [
+          0.4,
+          0.9999
+        ]
       ]
     ]
   ],
@@ -3885,7 +4553,11 @@
     ],
     [
       "defaults when empty",
-      { "features": { "feature": {} } },
+      {
+        "features": {
+          "feature": {}
+        }
+      },
       "feature",
       {
         "value": null,
@@ -3897,7 +4569,13 @@
     ],
     [
       "uses defaultValue - number",
-      { "features": { "feature": { "defaultValue": 1 } } },
+      {
+        "features": {
+          "feature": {
+            "defaultValue": 1
+          }
+        }
+      },
       "feature",
       {
         "value": 1,
@@ -3909,7 +4587,13 @@
     ],
     [
       "uses custom values - string",
-      { "features": { "feature": { "defaultValue": "yes" } } },
+      {
+        "features": {
+          "feature": {
+            "defaultValue": "yes"
+          }
+        }
+      },
       "feature",
       {
         "value": "yes",
@@ -4138,7 +4822,12 @@
               {
                 "force": 1,
                 "condition": {
-                  "country": { "$in": ["US", "CA"] },
+                  "country": {
+                    "$in": [
+                      "US",
+                      "CA"
+                    ]
+                  },
                   "browser": "firefox"
                 }
               }
@@ -4169,7 +4858,12 @@
               {
                 "force": 1,
                 "condition": {
-                  "country": { "$in": ["US", "CA"] },
+                  "country": {
+                    "$in": [
+                      "US",
+                      "CA"
+                    ]
+                  },
                   "browser": "firefox"
                 }
               }
@@ -4219,7 +4913,9 @@
       {
         "features": {
           "feature": {
-            "rules": [{}]
+            "rules": [
+              {}
+            ]
           }
         }
       },
@@ -4242,7 +4938,11 @@
           "feature": {
             "rules": [
               {
-                "variations": ["a", "b", "c"]
+                "variations": [
+                  "a",
+                  "b",
+                  "c"
+                ]
               }
             ]
           }
@@ -4255,7 +4955,11 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": ["a", "b", "c"]
+          "variations": [
+            "a",
+            "b",
+            "c"
+          ]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4284,7 +4988,11 @@
             "rules": [
               {
                 "id": "id",
-                "variations": ["a", "b", "c"]
+                "variations": [
+                  "a",
+                  "b",
+                  "c"
+                ]
               }
             ]
           }
@@ -4297,7 +5005,11 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": ["a", "b", "c"]
+          "variations": [
+            "a",
+            "b",
+            "c"
+          ]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4325,7 +5037,11 @@
           "feature": {
             "rules": [
               {
-                "variations": ["a", "b", "c"]
+                "variations": [
+                  "a",
+                  "b",
+                  "c"
+                ]
               }
             ]
           }
@@ -4338,7 +5054,11 @@
         "off": false,
         "experiment": {
           "key": "feature",
-          "variations": ["a", "b", "c"]
+          "variations": [
+            "a",
+            "b",
+            "c"
+          ]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4374,8 +5094,14 @@
                 "name": "Test",
                 "phase": "1",
                 "ranges": [
-                  [0, 0.1],
-                  [0.1, 1.0]
+                  [
+                    0,
+                    0.1
+                  ],
+                  [
+                    0.1,
+                    1.0
+                  ]
                 ],
                 "meta": [
                   {
@@ -4391,14 +5117,31 @@
                   {
                     "attribute": "anonId",
                     "seed": "pricing",
-                    "ranges": [[0, 1]]
+                    "ranges": [
+                      [
+                        0,
+                        1
+                      ]
+                    ]
                   }
                 ],
-                "namespace": ["pricing", 0, 1],
+                "namespace": [
+                  "pricing",
+                  0,
+                  1
+                ],
                 "key": "hello",
-                "variations": [true, false],
-                "weights": [0.1, 0.9],
-                "condition": { "premium": true },
+                "variations": [
+                  true,
+                  false
+                ],
+                "weights": [
+                  0.1,
+                  0.9
+                ],
+                "condition": {
+                  "premium": true
+                },
                 "foo": "bar"
               }
             ]
@@ -4414,8 +5157,14 @@
         "experiment": {
           "coverage": 0.99,
           "ranges": [
-            [0, 0.1],
-            [0.1, 1.0]
+            [
+              0,
+              0.1
+            ],
+            [
+              0.1,
+              1.0
+            ]
           ],
           "meta": [
             {
@@ -4431,7 +5180,12 @@
             {
               "attribute": "anonId",
               "seed": "pricing",
-              "ranges": [[0, 1]]
+              "ranges": [
+                [
+                  0,
+                  1
+                ]
+              ]
             }
           ],
           "name": "Test",
@@ -4439,11 +5193,23 @@
           "seed": "feature",
           "hashVersion": 2,
           "hashAttribute": "anonId",
-          "namespace": ["pricing", 0, 1],
+          "namespace": [
+            "pricing",
+            0,
+            1
+          ],
           "key": "hello",
-          "variations": [true, false],
-          "weights": [0.1, 0.9],
-          "condition": { "premium": true }
+          "variations": [
+            true,
+            false
+          ],
+          "weights": [
+            0.1,
+            0.9
+          ],
+          "condition": {
+            "premium": true
+          }
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4473,15 +5239,21 @@
             "rules": [
               {
                 "force": 1,
-                "condition": { "browser": "chrome" }
+                "condition": {
+                  "browser": "chrome"
+                }
               },
               {
                 "force": 2,
-                "condition": { "browser": "firefox" }
+                "condition": {
+                  "browser": "firefox"
+                }
               },
               {
                 "force": 3,
-                "condition": { "browser": "safari" }
+                "condition": {
+                  "browser": "safari"
+                }
               }
             ]
           }
@@ -4509,17 +5281,23 @@
               {
                 "force": 1,
                 "id": "1",
-                "condition": { "browser": "chrome" }
+                "condition": {
+                  "browser": "chrome"
+                }
               },
               {
                 "id": "2",
                 "force": 2,
-                "condition": { "browser": "firefox" }
+                "condition": {
+                  "browser": "firefox"
+                }
               },
               {
                 "id": "3",
                 "force": 3,
-                "condition": { "browser": "safari" }
+                "condition": {
+                  "browser": "safari"
+                }
               }
             ]
           }
@@ -4546,15 +5324,21 @@
             "rules": [
               {
                 "force": 1,
-                "condition": { "browser": "chrome" }
+                "condition": {
+                  "browser": "chrome"
+                }
               },
               {
                 "force": 2,
-                "condition": { "browser": "firefox" }
+                "condition": {
+                  "browser": "firefox"
+                }
               },
               {
                 "force": 3,
-                "condition": { "browser": "safari" }
+                "condition": {
+                  "browser": "safari"
+                }
               }
             ]
           }
@@ -4572,13 +5356,20 @@
     [
       "skips experiment on coverage",
       {
-        "attributes": { "id": "123" },
+        "attributes": {
+          "id": "123"
+        },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [0, 1, 2, 3],
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
                 "coverage": 0.01
               },
               {
@@ -4600,14 +5391,25 @@
     [
       "skips experiment on namespace",
       {
-        "attributes": { "id": "123" },
+        "attributes": {
+          "id": "123"
+        },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [0, 1, 2, 3],
-                "namespace": ["pricing", 0, 0.01]
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "namespace": [
+                  "pricing",
+                  0,
+                  0.01
+                ]
               },
               {
                 "force": 3
@@ -4628,13 +5430,18 @@
     [
       "handles integer hashAttribute",
       {
-        "attributes": { "id": 123 },
+        "attributes": {
+          "id": 123
+        },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [0, 1]
+                "variations": [
+                  0,
+                  1
+                ]
               }
             ]
           }
@@ -4648,7 +5455,10 @@
         "source": "experiment",
         "experiment": {
           "key": "feature",
-          "variations": [0, 1]
+          "variations": [
+            0,
+            1
+          ]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4668,13 +5478,20 @@
     [
       "skip experiment on missing hashAttribute",
       {
-        "attributes": { "id": "123" },
+        "attributes": {
+          "id": "123"
+        },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [0, 1, 2, 3],
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
                 "hashAttribute": "company"
               },
               {
@@ -4696,7 +5513,9 @@
     [
       "include experiments when forced",
       {
-        "attributes": { "id": "123" },
+        "attributes": {
+          "id": "123"
+        },
         "forcedVariations": {
           "feature": 1
         },
@@ -4705,7 +5524,12 @@
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [0, 1, 2, 3]
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ]
               },
               {
                 "force": 3
@@ -4722,7 +5546,12 @@
         "source": "experiment",
         "experiment": {
           "key": "feature",
-          "variations": [0, 1, 2, 3]
+          "variations": [
+            0,
+            1,
+            2,
+            3
+          ]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -4751,7 +5580,10 @@
               {
                 "force": 2,
                 "coverage": 0.01,
-                "range": [0, 0.99]
+                "range": [
+                  0,
+                  0.99
+                ]
               }
             ]
           }
@@ -4779,7 +5611,10 @@
               {
                 "force": 2,
                 "hashVersion": 2,
-                "range": [0.96, 0.97]
+                "range": [
+                  0.96,
+                  0.97
+                ]
               }
             ]
           }
@@ -4806,7 +5641,10 @@
             "rules": [
               {
                 "force": 2,
-                "range": [0, 0.01]
+                "range": [
+                  0,
+                  0.01
+                ]
               }
             ]
           }
@@ -4836,7 +5674,12 @@
                 "filters": [
                   {
                     "seed": "seed",
-                    "ranges": [[0, 0.01]]
+                    "ranges": [
+                      [
+                        0,
+                        0.01
+                      ]
+                    ]
                   }
                 ]
               }
@@ -4865,7 +5708,10 @@
             "rules": [
               {
                 "force": 2,
-                "range": [0, 0.5],
+                "range": [
+                  0,
+                  0.5
+                ],
                 "seed": "fjdslafdsa",
                 "hashVersion": 2
               }
@@ -4894,11 +5740,20 @@
             "rules": [
               {
                 "key": "holdout",
-                "variations": [1, 2],
+                "variations": [
+                  1,
+                  2
+                ],
                 "hashVersion": 2,
                 "ranges": [
-                  [0, 0.01],
-                  [0.01, 1.0]
+                  [
+                    0,
+                    0.01
+                  ],
+                  [
+                    0.01,
+                    1.0
+                  ]
                 ],
                 "meta": [
                   {},
@@ -4909,11 +5764,20 @@
               },
               {
                 "key": "experiment",
-                "variations": [3, 4],
+                "variations": [
+                  3,
+                  4
+                ],
                 "hashVersion": 2,
                 "ranges": [
-                  [0, 0.5],
-                  [0.5, 1.0]
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
                 ]
               }
             ]
@@ -4929,10 +5793,19 @@
         "experiment": {
           "key": "experiment",
           "hashVersion": 2,
-          "variations": [3, 4],
+          "variations": [
+            3,
+            4
+          ],
           "ranges": [
-            [0, 0.5],
-            [0.5, 1.0]
+            [
+              0,
+              0.5
+            ],
+            [
+              0.5,
+              1.0
+            ]
           ]
         },
         "experimentResult": {
@@ -4963,10 +5836,19 @@
               {
                 "key": "holdout",
                 "hashVersion": 2,
-                "variations": [1, 2],
+                "variations": [
+                  1,
+                  2
+                ],
                 "ranges": [
-                  [0, 0.99],
-                  [0.99, 1.0]
+                  [
+                    0,
+                    0.99
+                  ],
+                  [
+                    0.99,
+                    1.0
+                  ]
                 ],
                 "meta": [
                   {},
@@ -4978,10 +5860,19 @@
               {
                 "key": "experiment",
                 "hashVersion": 2,
-                "variations": [3, 4],
+                "variations": [
+                  3,
+                  4
+                ],
                 "ranges": [
-                  [0, 0.5],
-                  [0.5, 1.0]
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
                 ]
               }
             ]
@@ -4997,8 +5888,14 @@
         "experiment": {
           "hashVersion": 2,
           "ranges": [
-            [0, 0.99],
-            [0.99, 1.0]
+            [
+              0,
+              0.99
+            ],
+            [
+              0.99,
+              1.0
+            ]
           ],
           "meta": [
             {},
@@ -5007,7 +5904,10 @@
             }
           ],
           "key": "holdout",
-          "variations": [1, 2]
+          "variations": [
+            1,
+            2
+          ]
         },
         "experimentResult": {
           "featureId": "feature",
@@ -5037,11 +5937,20 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": { "country": "Canada" },
+                "condition": {
+                  "country": "Canada"
+                },
                 "force": "red"
               },
               {
-                "condition": { "country": { "$in": ["USA", "Mexico"] } },
+                "condition": {
+                  "country": {
+                    "$in": [
+                      "USA",
+                      "Mexico"
+                    ]
+                  }
+                },
                 "force": "green"
               }
             ]
@@ -5053,13 +5962,17 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": { "value": "green" },
+                    "condition": {
+                      "value": "green"
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "memberType": "basic" },
+                "condition": {
+                  "memberType": "basic"
+                },
                 "force": "success"
               }
             ]
@@ -5091,13 +6004,17 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": { "value": "green" },
+                    "condition": {
+                      "value": "green"
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "memberType": "basic" },
+                "condition": {
+                  "memberType": "basic"
+                },
                 "force": "success"
               }
             ]
@@ -5126,11 +6043,20 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": { "country": "Canada" },
+                "condition": {
+                  "country": "Canada"
+                },
                 "force": "red"
               },
               {
-                "condition": { "country": { "$in": ["USA", "Mexico"] } },
+                "condition": {
+                  "country": {
+                    "$in": [
+                      "USA",
+                      "Mexico"
+                    ]
+                  }
+                },
                 "force": "green"
               }
             ]
@@ -5142,13 +6068,17 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": { "value": "green" },
+                    "condition": {
+                      "value": "green"
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "memberType": "basic" },
+                "condition": {
+                  "memberType": "basic"
+                },
                 "force": "success"
               }
             ]
@@ -5177,11 +6107,20 @@
             "defaultValue": "silver",
             "rules": [
               {
-                "condition": { "country": "Canada" },
+                "condition": {
+                  "country": "Canada"
+                },
                 "force": "red"
               },
               {
-                "condition": { "country": { "$in": ["USA", "Mexico"] } },
+                "condition": {
+                  "country": {
+                    "$in": [
+                      "USA",
+                      "Mexico"
+                    ]
+                  }
+                },
                 "force": "green"
               }
             ]
@@ -5190,7 +6129,9 @@
             "defaultValue": 0,
             "rules": [
               {
-                "condition": { "id": "123" },
+                "condition": {
+                  "id": "123"
+                },
                 "force": 2
               }
             ]
@@ -5202,7 +6143,9 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag1",
-                    "condition": { "value": "green" },
+                    "condition": {
+                      "value": "green"
+                    },
                     "gate": true
                   }
                 ]
@@ -5211,13 +6154,19 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag2",
-                    "condition": { "value": { "$gt": 1 } },
+                    "condition": {
+                      "value": {
+                        "$gt": 1
+                      }
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "memberType": "basic" },
+                "condition": {
+                  "memberType": "basic"
+                },
                 "force": "success"
               }
             ]
@@ -5249,17 +6198,30 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag2",
-                    "condition": { "value": { "$gt": 1 } },
+                    "condition": {
+                      "value": {
+                        "$gt": 1
+                      }
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "country": "Canada" },
+                "condition": {
+                  "country": "Canada"
+                },
                 "force": "red"
               },
               {
-                "condition": { "country": { "$in": ["USA", "Mexico"] } },
+                "condition": {
+                  "country": {
+                    "$in": [
+                      "USA",
+                      "Mexico"
+                    ]
+                  }
+                },
                 "force": "green"
               }
             ]
@@ -5268,7 +6230,9 @@
             "defaultValue": 0,
             "rules": [
               {
-                "condition": { "id": "123" },
+                "condition": {
+                  "id": "123"
+                },
                 "force": 2
               }
             ]
@@ -5280,13 +6244,17 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag1",
-                    "condition": { "value": "green" },
+                    "condition": {
+                      "value": "green"
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "memberType": "basic" },
+                "condition": {
+                  "memberType": "basic"
+                },
                 "force": "success"
               }
             ]
@@ -5316,12 +6284,21 @@
             "rules": [
               {
                 "key": "experiment",
-                "variations": [0, 1],
+                "variations": [
+                  0,
+                  1
+                ],
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "ranges": [
-                  [0, 0.5],
-                  [0.5, 1.0]
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
                 ]
               }
             ]
@@ -5333,13 +6310,17 @@
                 "parentConditions": [
                   {
                     "id": "parentExperimentFlag",
-                    "condition": { "value": 1 },
+                    "condition": {
+                      "value": 1
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "memberType": "basic" },
+                "condition": {
+                  "memberType": "basic"
+                },
                 "force": "success"
               }
             ]
@@ -5369,12 +6350,21 @@
             "rules": [
               {
                 "key": "experiment",
-                "variations": [0, 1],
+                "variations": [
+                  0,
+                  1
+                ],
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "ranges": [
-                  [0, 0.5],
-                  [0.5, 1.0]
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
                 ]
               }
             ]
@@ -5386,13 +6376,17 @@
                 "parentConditions": [
                   {
                     "id": "parentExperimentFlag",
-                    "condition": { "value": 0 },
+                    "condition": {
+                      "value": 0
+                    },
                     "gate": true
                   }
                 ]
               },
               {
-                "condition": { "memberType": "basic" },
+                "condition": {
+                  "memberType": "basic"
+                },
                 "force": "success"
               }
             ]
@@ -5422,7 +6416,9 @@
                 "parentConditions": [
                   {
                     "id": "flag2",
-                    "condition": { "value": true },
+                    "condition": {
+                      "value": true
+                    },
                     "gate": true
                   }
                 ]
@@ -5436,7 +6432,9 @@
                 "parentConditions": [
                   {
                     "id": "flag1",
-                    "condition": { "value": true },
+                    "condition": {
+                      "value": true
+                    },
                     "gate": true
                   }
                 ]
@@ -5469,12 +6467,18 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": { "value": { "$ne": false } },
+                    "condition": {
+                      "value": {
+                        "$ne": false
+                      }
+                    },
                     "gate": true
                   },
                   {
                     "id": "parentFlag",
-                    "condition": { "value": true },
+                    "condition": {
+                      "value": true
+                    },
                     "gate": true
                   }
                 ]
@@ -5486,19 +6490,25 @@
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": { "value": true }
+                    "condition": {
+                      "value": true
+                    }
                   }
                 ],
                 "force": "C"
               },
               {
                 "condition": {
-                  "browser": { "$ne": "safari" }
+                  "browser": {
+                    "$ne": "safari"
+                  }
                 },
                 "parentConditions": [
                   {
                     "id": "parentFlag",
-                    "condition": { "value": true }
+                    "condition": {
+                      "value": true
+                    }
                   }
                 ],
                 "force": "T"
@@ -5531,7 +6541,9 @@
             "defaultValue": "ui_default",
             "rules": [
               {
-                "condition": { "public_user_id": "pid_eci:does_not_match" },
+                "condition": {
+                  "public_user_id": "pid_eci:does_not_match"
+                },
                 "force": "ui_default"
               }
             ]
@@ -5543,7 +6555,9 @@
                 "parentConditions": [
                   {
                     "id": "probeFeature",
-                    "condition": { "value": "ON" }
+                    "condition": {
+                      "value": "ON"
+                    }
                   }
                 ],
                 "force": "prereqon"
@@ -5552,7 +6566,11 @@
                 "parentConditions": [
                   {
                     "id": "probeFeature",
-                    "condition": { "value": { "$ne": "ON" } }
+                    "condition": {
+                      "value": {
+                        "$ne": "ON"
+                      }
+                    }
                   }
                 ],
                 "force": "prereqoff"
@@ -5582,13 +6600,20 @@
             "rules": [
               {
                 "force": true,
-                "condition": { "id": { "$inGroup": "group_id" } }
+                "condition": {
+                  "id": {
+                    "$inGroup": "group_id"
+                  }
+                }
               }
             ]
           }
         },
         "savedGroups": {
-          "group_id": [123, 456]
+          "group_id": [
+            123,
+            456
+          ]
         }
       },
       "inGroup_force_rule",
@@ -5612,19 +6637,35 @@
             "rules": [
               {
                 "key": "experiment",
-                "condition": { "id": { "$inGroup": "group_id" } },
+                "condition": {
+                  "id": {
+                    "$inGroup": "group_id"
+                  }
+                },
                 "hashVersion": 2,
-                "variations": [1, 2],
+                "variations": [
+                  1,
+                  2
+                ],
                 "ranges": [
-                  [0, 0.5],
-                  [0.5, 1.0]
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
                 ]
               }
             ]
           }
         },
         "savedGroups": {
-          "group_id": [123, 456]
+          "group_id": [
+            123,
+            456
+          ]
         }
       },
       "inGroup_experiment_rule",
@@ -5635,11 +6676,24 @@
         "source": "experiment",
         "experiment": {
           "hashVersion": 2,
-          "condition": { "id": { "$inGroup": "group_id" } },
-          "variations": [1, 2],
+          "condition": {
+            "id": {
+              "$inGroup": "group_id"
+            }
+          },
+          "variations": [
+            1,
+            2
+          ],
           "ranges": [
-            [0, 0.5],
-            [0.5, 1.0]
+            [
+              0,
+              0.5
+            ],
+            [
+              0.5,
+              1.0
+            ]
           ],
           "key": "experiment"
         },
@@ -5792,333 +6846,1035 @@
         "source": "force",
         "ruleId": ""
       }
+    ],
+    [
+      "multi-armed-bandit type is treated as a standard experiment",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "type": "multi-armed-bandit"
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "standard type is treated as a standard experiment",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "type": "standard"
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "unknown bandit fields on a non-CB rule are ignored",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "banditVersion": 9
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
     ]
   ],
   "run": [
     [
       "default weights - 1",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "default weights - 2",
-      { "attributes": { "id": "2" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "2"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "default weights - 3",
-      { "attributes": { "id": "3" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "3"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "default weights - 4",
-      { "attributes": { "id": "4" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "4"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "default weights - 5",
-      { "attributes": { "id": "5" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "5"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "default weights - 6",
-      { "attributes": { "id": "6" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "6"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "default weights - 7",
-      { "attributes": { "id": "7" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "7"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "default weights - 8",
-      { "attributes": { "id": "8" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "8"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "default weights - 9",
-      { "attributes": { "id": "9" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "9"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "uneven weights - 1",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "uneven weights - 2",
-      { "attributes": { "id": "2" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "2"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "uneven weights - 3",
-      { "attributes": { "id": "3" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "3"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "uneven weights - 4",
-      { "attributes": { "id": "4" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "4"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "uneven weights - 5",
-      { "attributes": { "id": "5" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "5"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "uneven weights - 6",
-      { "attributes": { "id": "6" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "6"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "uneven weights - 7",
-      { "attributes": { "id": "7" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "7"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "uneven weights - 8",
-      { "attributes": { "id": "8" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "8"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "uneven weights - 9",
-      { "attributes": { "id": "9" } },
-      { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
+      {
+        "attributes": {
+          "id": "9"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "coverage - 1",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       0,
       false,
       false
     ],
     [
       "coverage - 2",
-      { "attributes": { "id": "2" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "2"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       0,
       true,
       true
     ],
     [
       "coverage - 3",
-      { "attributes": { "id": "3" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "3"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       0,
       true,
       true
     ],
     [
       "coverage - 4",
-      { "attributes": { "id": "4" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "4"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       0,
       false,
       false
     ],
     [
       "coverage - 5",
-      { "attributes": { "id": "5" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "5"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       1,
       true,
       true
     ],
     [
       "coverage - 6",
-      { "attributes": { "id": "6" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "6"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       0,
       false,
       false
     ],
     [
       "coverage - 7",
-      { "attributes": { "id": "7" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "7"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       0,
       true,
       true
     ],
     [
       "coverage - 8",
-      { "attributes": { "id": "8" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "8"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       1,
       true,
       true
     ],
     [
       "coverage - 9",
-      { "attributes": { "id": "9" } },
-      { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
+      {
+        "attributes": {
+          "id": "9"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
       0,
       false,
       false
     ],
     [
       "three way test - 1",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       2,
       true,
       true
     ],
     [
       "three way test - 2",
-      { "attributes": { "id": "2" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "2"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "three way test - 3",
-      { "attributes": { "id": "3" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "3"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "three way test - 4",
-      { "attributes": { "id": "4" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "4"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       2,
       true,
       true
     ],
     [
       "three way test - 5",
-      { "attributes": { "id": "5" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "5"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "three way test - 6",
-      { "attributes": { "id": "6" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "6"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       2,
       true,
       true
     ],
     [
       "three way test - 7",
-      { "attributes": { "id": "7" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "7"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "three way test - 8",
-      { "attributes": { "id": "8" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "8"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "three way test - 9",
-      { "attributes": { "id": "9" } },
-      { "key": "my-test", "variations": [0, 1, 2] },
+      {
+        "attributes": {
+          "id": "9"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "test name - my-test",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       1,
       true,
       true
     ],
     [
       "test name - my-test-3",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test-3", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test-3",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       true,
       true
     ],
     [
       "empty id",
-      { "attributes": { "id": "" } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": ""
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       false,
       false
     ],
     [
       "null id",
-      { "attributes": { "id": null } },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {
+          "id": null
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       false,
       false
     ],
     [
       "missing id",
-      { "attributes": {} },
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "attributes": {}
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       false,
       false
@@ -6126,31 +7882,68 @@
     [
       "missing attributes",
       {},
-      { "key": "my-test", "variations": [0, 1] },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
       0,
       false,
       false
     ],
     [
       "single variation",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0] },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0
+        ]
+      },
       0,
       false,
       false
     ],
     [
       "negative forced variation",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0, 1], "force": -8 },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "force": -8
+      },
       0,
       false,
       false
     ],
     [
       "high forced variation",
-      { "attributes": { "id": "1" } },
-      { "key": "my-test", "variations": [0, 1], "force": 25 },
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "force": 25
+      },
       0,
       false,
       false
@@ -6165,7 +7958,10 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "condition": {
           "browser": "firefox"
         }
@@ -6184,7 +7980,10 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "condition": {
           "browser": "firefox"
         }
@@ -6203,7 +8002,10 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "hashAttribute": "companyId"
       },
       1,
@@ -6220,7 +8022,10 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       0,
       false,
@@ -6236,7 +8041,10 @@
       },
       {
         "key": "forced-test-qs",
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       1,
       true,
@@ -6252,7 +8060,10 @@
       {
         "key": "my-test",
         "active": true,
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       1,
       true,
@@ -6268,7 +8079,10 @@
       {
         "key": "my-test",
         "active": false,
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       0,
       false,
@@ -6285,7 +8099,10 @@
       {
         "key": "my-test",
         "active": false,
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       1,
       true,
@@ -6302,7 +8119,10 @@
         "key": "my-test",
         "force": 1,
         "coverage": 0.01,
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       0,
       false,
@@ -6338,12 +8158,19 @@
     [
       "Force variation from context",
       {
-        "attributes": { "id": "1" },
-        "forcedVariations": { "my-test": 0 }
+        "attributes": {
+          "id": "1"
+        },
+        "forcedVariations": {
+          "my-test": 0
+        }
       },
       {
         "key": "my-test",
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       0,
       true,
@@ -6352,12 +8179,17 @@
     [
       "Skips experiments in QA mode",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "qaMode": true
       },
       {
         "key": "my-test",
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       0,
       false,
@@ -6366,13 +8198,20 @@
     [
       "Works in QA mode if forced in context",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "qaMode": true,
-        "forcedVariations": { "my-test": 1 }
+        "forcedVariations": {
+          "my-test": 1
+        }
       },
       {
         "key": "my-test",
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       1,
       true,
@@ -6381,12 +8220,17 @@
     [
       "Works in QA mode if forced in experiment",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "qaMode": true
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "force": 1
       },
       1,
@@ -6402,8 +8246,15 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
-        "namespace": ["namespace", 0.1, 1]
+        "variations": [
+          0,
+          1
+        ],
+        "namespace": [
+          "namespace",
+          0.1,
+          1
+        ]
       },
       1,
       true,
@@ -6418,8 +8269,15 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
-        "namespace": ["namespace", 0, 0.1]
+        "variations": [
+          0,
+          1
+        ],
+        "namespace": [
+          "namespace",
+          0,
+          0.1
+        ]
       },
       0,
       false,
@@ -6434,7 +8292,10 @@
       },
       {
         "key": "no-coverage",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "coverage": 0
       },
       0,
@@ -6451,19 +8312,33 @@
       },
       {
         "key": "filtered",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [0, 0.1],
-              [0.2, 0.4]
+              [
+                0,
+                0.1
+              ],
+              [
+                0.2,
+                0.4
+              ]
             ]
           },
           {
             "seed": "seed",
             "attribute": "anonId",
-            "ranges": [[0.8, 1.0]]
+            "ranges": [
+              [
+                0.8,
+                1.0
+              ]
+            ]
           }
         ]
       },
@@ -6481,19 +8356,33 @@
       },
       {
         "key": "filtered",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [0, 0.1],
-              [0.2, 0.4]
+              [
+                0,
+                0.1
+              ],
+              [
+                0.2,
+                0.4
+              ]
             ]
           },
           {
             "seed": "seed",
             "attribute": "anonId",
-            "ranges": [[0.6, 0.8]]
+            "ranges": [
+              [
+                0.6,
+                0.8
+              ]
+            ]
           }
         ]
       },
@@ -6510,17 +8399,30 @@
       },
       {
         "key": "filtered",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "filters": [
           {
             "seed": "seed",
             "ranges": [
-              [0, 0.1],
-              [0.2, 0.4]
+              [
+                0,
+                0.1
+              ],
+              [
+                0.2,
+                0.4
+              ]
             ]
           }
         ],
-        "namespace": ["test", 0, 0.001]
+        "namespace": [
+          "test",
+          0,
+          0.001
+        ]
       },
       1,
       true,
@@ -6535,13 +8437,25 @@
       },
       {
         "key": "ranges",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "ranges": [
-          [0.99, 1.0],
-          [0.0, 0.99]
+          [
+            0.99,
+            1.0
+          ],
+          [
+            0.0,
+            0.99
+          ]
         ],
         "coverage": 0.01,
-        "weights": [0.99, 0.01]
+        "weights": [
+          0.99,
+          0.01
+        ]
       },
       1,
       true,
@@ -6556,10 +8470,19 @@
       },
       {
         "key": "configs",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "ranges": [
-          [0, 0.1],
-          [0.9, 1.0]
+          [
+            0,
+            0.1
+          ],
+          [
+            0.9,
+            1.0
+          ]
         ]
       },
       0,
@@ -6577,10 +8500,19 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "ranges": [
-          [0, 0.5],
-          [0.5, 1.0]
+          [
+            0,
+            0.5
+          ],
+          [
+            0.5,
+            1.0
+          ]
         ]
       },
       1,
@@ -6598,7 +8530,10 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [0, 1]
+        "variations": [
+          0,
+          1
+        ]
       },
       1,
       true,
@@ -6615,8 +8550,14 @@
         "key": "key",
         "seed": "foo",
         "hashVersion": 2,
-        "variations": [0, 1],
-        "weights": [0.5, 0.5],
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.5,
+          0.5
+        ],
         "coverage": 0.99
       },
       1,
@@ -6626,7 +8567,9 @@
     [
       "Prerequisite condition passes",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "features": {
           "parentFlag": {
             "defaultValue": true
@@ -6635,7 +8578,10 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "parentConditions": [
           {
             "id": "parentFlag",
@@ -6652,7 +8598,9 @@
     [
       "Prerequisite condition fails",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "features": {
           "parentFlag": {
             "defaultValue": false
@@ -6661,7 +8609,10 @@
       },
       {
         "key": "my-test",
-        "variations": [0, 1],
+        "variations": [
+          0,
+          1
+        ],
         "parentConditions": [
           {
             "id": "parentFlag",
@@ -6678,15 +8629,29 @@
     [
       "SavedGroups correctly pulled from context for experiment",
       {
-        "attributes": { "id": "4" },
-        "savedGroups": { "group_id": ["4", "5", "6"] }
+        "attributes": {
+          "id": "4"
+        },
+        "savedGroups": {
+          "group_id": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
       },
       {
         "key": "group-filtered-test",
         "condition": {
-          "id": { "$inGroup": "group_id" }
+          "id": {
+            "$inGroup": "group_id"
+          }
         },
-        "variations": [0, 1, 2]
+        "variations": [
+          0,
+          1,
+          2
+        ]
       },
       0,
       true,
@@ -6698,8 +8663,14 @@
       "even range, 0.2",
       0.2,
       [
-        [0, 0.5],
-        [0.5, 1]
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ],
       0
     ],
@@ -6707,8 +8678,14 @@
       "even range, 0.4",
       0.4,
       [
-        [0, 0.5],
-        [0.5, 1]
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ],
       0
     ],
@@ -6716,8 +8693,14 @@
       "even range, 0.6",
       0.6,
       [
-        [0, 0.5],
-        [0.5, 1]
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ],
       1
     ],
@@ -6725,8 +8708,14 @@
       "even range, 0.8",
       0.8,
       [
-        [0, 0.5],
-        [0.5, 1]
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ],
       1
     ],
@@ -6734,8 +8723,14 @@
       "even range, 0",
       0,
       [
-        [0, 0.5],
-        [0.5, 1]
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ],
       0
     ],
@@ -6743,8 +8738,14 @@
       "even range, 0.5",
       0.5,
       [
-        [0, 0.5],
-        [0.5, 1]
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ],
       1
     ],
@@ -6752,8 +8753,14 @@
       "reduced range, 0.2",
       0.2,
       [
-        [0, 0.25],
-        [0.5, 0.75]
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
       ],
       0
     ],
@@ -6761,8 +8768,14 @@
       "reduced range, 0.4",
       0.4,
       [
-        [0, 0.25],
-        [0.5, 0.75]
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
       ],
       -1
     ],
@@ -6770,8 +8783,14 @@
       "reduced range, 0.6",
       0.6,
       [
-        [0, 0.25],
-        [0.5, 0.75]
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
       ],
       1
     ],
@@ -6779,8 +8798,14 @@
       "reduced range, 0.8",
       0.8,
       [
-        [0, 0.25],
-        [0.5, 0.75]
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
       ],
       -1
     ],
@@ -6788,8 +8813,14 @@
       "reduced range, 0.25",
       0.25,
       [
-        [0, 0.25],
-        [0.5, 0.75]
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
       ],
       -1
     ],
@@ -6797,8 +8828,14 @@
       "reduced range, 0.5",
       0.5,
       [
-        [0, 0.25],
-        [0.5, 0.75]
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
       ],
       1
     ],
@@ -6806,17 +8843,44 @@
       "zero range",
       0.5,
       [
-        [0, 0.5],
-        [0.5, 0.5],
-        [0.5, 1]
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
       ],
       2
     ]
   ],
   "getQueryStringOverride": [
-    ["empty url", "my-test", "", 2, null],
-    ["no query string", "my-test", "http://example.com", 2, null],
-    ["empty query string", "my-test", "http://example.com?", 2, null],
+    [
+      "empty url",
+      "my-test",
+      "",
+      2,
+      null
+    ],
+    [
+      "no query string",
+      "my-test",
+      "http://example.com",
+      2,
+      null
+    ],
+    [
+      "empty query string",
+      "my-test",
+      "http://example.com?",
+      2,
+      null
+    ],
     [
       "no query string match",
       "my-test",
@@ -6824,14 +8888,62 @@
       2,
       null
     ],
-    ["invalid query string", "my-test", "http://example.com??&&&?#", 2, null],
-    ["simple match 0", "my-test", "http://example.com?my-test=0", 2, 0],
-    ["simple match 1", "my-test", "http://example.com?my-test=1", 2, 1],
-    ["negative variation", "my-test", "http://example.com?my-test=-1", 2, null],
-    ["float", "my-test", "http://example.com?my-test=2.054", 2, null],
-    ["string", "my-test", "http://example.com?my-test=foo", 2, null],
-    ["variation too high", "my-test", "http://example.com?my-test=5", 2, null],
-    ["high numVariations", "my-test", "http://example.com?my-test=5", 6, 5],
+    [
+      "invalid query string",
+      "my-test",
+      "http://example.com??&&&?#",
+      2,
+      null
+    ],
+    [
+      "simple match 0",
+      "my-test",
+      "http://example.com?my-test=0",
+      2,
+      0
+    ],
+    [
+      "simple match 1",
+      "my-test",
+      "http://example.com?my-test=1",
+      2,
+      1
+    ],
+    [
+      "negative variation",
+      "my-test",
+      "http://example.com?my-test=-1",
+      2,
+      null
+    ],
+    [
+      "float",
+      "my-test",
+      "http://example.com?my-test=2.054",
+      2,
+      null
+    ],
+    [
+      "string",
+      "my-test",
+      "http://example.com?my-test=foo",
+      2,
+      null
+    ],
+    [
+      "variation too high",
+      "my-test",
+      "http://example.com?my-test=5",
+      2,
+      null
+    ],
+    [
+      "high numVariations",
+      "my-test",
+      "http://example.com?my-test=5",
+      6,
+      5
+    ],
     [
       "equal to numVariations",
       "my-test",
@@ -6853,33 +8965,215 @@
       2,
       1
     ],
-    ["anchor", "my-test", "http://example.com?my-test=1#foo", 2, 1]
+    [
+      "anchor",
+      "my-test",
+      "http://example.com?my-test=1#foo",
+      2,
+      1
+    ]
   ],
   "inNamespace": [
-    ["user 1, namespace1, 1", "1", ["namespace1", 0, 0.4], false],
-    ["user 1, namespace1, 2", "1", ["namespace1", 0.4, 1], true],
-    ["user 1, namespace2, 1", "1", ["namespace2", 0, 0.4], false],
-    ["user 1, namespace2, 2", "1", ["namespace2", 0.4, 1], true],
-    ["user 2, namespace1, 1", "2", ["namespace1", 0, 0.4], false],
-    ["user 2, namespace1, 2", "2", ["namespace1", 0.4, 1], true],
-    ["user 2, namespace2, 1", "2", ["namespace2", 0, 0.4], false],
-    ["user 2, namespace2, 2", "2", ["namespace2", 0.4, 1], true],
-    ["user 3, namespace1, 1", "3", ["namespace1", 0, 0.4], false],
-    ["user 3, namespace1, 2", "3", ["namespace1", 0.4, 1], true],
-    ["user 3, namespace2, 1", "3", ["namespace2", 0, 0.4], true],
-    ["user 3, namespace2, 2", "3", ["namespace2", 0.4, 1], false],
-    ["user 4, namespace1, 1", "4", ["namespace1", 0, 0.4], false],
-    ["user 4, namespace1, 2", "4", ["namespace1", 0.4, 1], true],
-    ["user 4, namespace2, 1", "4", ["namespace2", 0, 0.4], true],
-    ["user 4, namespace2, 2", "4", ["namespace2", 0.4, 1], false]
+    [
+      "user 1, namespace1, 1",
+      "1",
+      [
+        "namespace1",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 1, namespace1, 2",
+      "1",
+      [
+        "namespace1",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 1, namespace2, 1",
+      "1",
+      [
+        "namespace2",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 1, namespace2, 2",
+      "1",
+      [
+        "namespace2",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 2, namespace1, 1",
+      "2",
+      [
+        "namespace1",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 2, namespace1, 2",
+      "2",
+      [
+        "namespace1",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 2, namespace2, 1",
+      "2",
+      [
+        "namespace2",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 2, namespace2, 2",
+      "2",
+      [
+        "namespace2",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 3, namespace1, 1",
+      "3",
+      [
+        "namespace1",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 3, namespace1, 2",
+      "3",
+      [
+        "namespace1",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 3, namespace2, 1",
+      "3",
+      [
+        "namespace2",
+        0,
+        0.4
+      ],
+      true
+    ],
+    [
+      "user 3, namespace2, 2",
+      "3",
+      [
+        "namespace2",
+        0.4,
+        1
+      ],
+      false
+    ],
+    [
+      "user 4, namespace1, 1",
+      "4",
+      [
+        "namespace1",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 4, namespace1, 2",
+      "4",
+      [
+        "namespace1",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 4, namespace2, 1",
+      "4",
+      [
+        "namespace2",
+        0,
+        0.4
+      ],
+      true
+    ],
+    [
+      "user 4, namespace2, 2",
+      "4",
+      [
+        "namespace2",
+        0.4,
+        1
+      ],
+      false
+    ]
   ],
   "getEqualWeights": [
-    [-1, []],
-    [0, []],
-    [1, [1]],
-    [2, [0.5, 0.5]],
-    [3, [0.33333333, 0.33333333, 0.33333333]],
-    [4, [0.25, 0.25, 0.25, 0.25]]
+    [
+      -1,
+      []
+    ],
+    [
+      0,
+      []
+    ],
+    [
+      1,
+      [
+        1
+      ]
+    ],
+    [
+      2,
+      [
+        0.5,
+        0.5
+      ]
+    ],
+    [
+      3,
+      [
+        0.33333333,
+        0.33333333,
+        0.33333333
+      ]
+    ],
+    [
+      4,
+      [
+        0.25,
+        0.25,
+        0.25,
+        0.25
+      ]
+    ]
   ],
   "decrypt": [
     [
@@ -6947,13 +9241,20 @@
     [
       "use fallbackAttribute when missing hashAttribute",
       {
-        "attributes": { "anonymousId": "123" },
+        "attributes": {
+          "anonymousId": "123"
+        },
         "features": {
           "feature": {
             "defaultValue": 0,
             "rules": [
               {
-                "variations": [0, 1, 2, 3],
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
                 "hashAttribute": "id",
                 "fallbackAttribute": "anonymousId"
               }
@@ -6977,7 +9278,9 @@
       },
       {
         "anonymousId||123": {
-          "assignments": { "feature__0": "3" },
+          "assignments": {
+            "feature__0": "3"
+          },
           "attributeName": "anonymousId",
           "attributeValue": "123"
         }
@@ -7003,11 +9306,31 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -7031,7 +9354,9 @@
       },
       {
         "deviceId||d123": {
-          "assignments": { "feature-exp__0": "1" },
+          "assignments": {
+            "feature-exp__0": "1"
+          },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -7057,11 +9382,31 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -7092,7 +9437,9 @@
       },
       {
         "deviceId||d123": {
-          "assignments": { "feature-exp__0": "2" },
+          "assignments": {
+            "feature-exp__0": "2"
+          },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -7118,11 +9465,31 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -7153,7 +9520,9 @@
       },
       {
         "deviceId||d123": {
-          "assignments": { "feature-exp__0": "1" },
+          "assignments": {
+            "feature-exp__0": "1"
+          },
           "attributeName": "deviceId",
           "attributeValue": "d123"
         }
@@ -7179,11 +9548,31 @@
                 "fallbackAttribute": "anonymousId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -7214,12 +9603,16 @@
       },
       {
         "anonymousId||ses123": {
-          "assignments": { "feature-exp__0": "1" },
+          "assignments": {
+            "feature-exp__0": "1"
+          },
           "attributeName": "anonymousId",
           "attributeValue": "ses123"
         },
         "id||i123": {
-          "assignments": { "feature-exp__0": "1" },
+          "assignments": {
+            "feature-exp__0": "1"
+          },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -7245,11 +9638,31 @@
                 "fallbackAttribute": "anonymousId",
                 "hashVersion": 2,
                 "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -7287,12 +9700,16 @@
       },
       {
         "anonymousId||ses123": {
-          "assignments": { "feature-exp__0": "2" },
+          "assignments": {
+            "feature-exp__0": "2"
+          },
           "attributeName": "anonymousId",
           "attributeValue": "ses123"
         },
         "id||i123": {
-          "assignments": { "feature-exp__0": "1" },
+          "assignments": {
+            "feature-exp__0": "1"
+          },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -7317,11 +9734,31 @@
                 "fallbackAttribute": "deviceId",
                 "hashVersion": 2,
                 "bucketVersion": 3,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -7330,7 +9767,9 @@
       },
       [
         {
-          "assignments": { "feature-exp__0": "1" },
+          "assignments": {
+            "feature-exp__0": "1"
+          },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -7379,11 +9818,31 @@
                 "hashVersion": 2,
                 "bucketVersion": 3,
                 "minBucketVersion": 3,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -7392,7 +9851,9 @@
       },
       [
         {
-          "assignments": { "feature-exp__0": "1" },
+          "assignments": {
+            "feature-exp__0": "1"
+          },
           "attributeName": "id",
           "attributeValue": "i123"
         }
@@ -7429,11 +9890,31 @@
                 "hashVersion": 2,
                 "bucketVersion": 1,
                 "disableStickyBucketing": true,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
                 "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
                 "phase": "0"
               }
             ]
@@ -7444,7 +9925,9 @@
         {
           "attributeName": "id",
           "attributeValue": "i123",
-          "assignments": { "feature-exp__0": "1" }
+          "assignments": {
+            "feature-exp__0": "1"
+          }
         }
       ],
       "exp1",
@@ -7464,7 +9947,9 @@
         "id||i123": {
           "attributeName": "id",
           "attributeValue": "i123",
-          "assignments": { "feature-exp__0": "1" }
+          "assignments": {
+            "feature-exp__0": "1"
+          }
         }
       }
     ],
@@ -7800,7 +10285,9 @@
     [
       "redirects correctly without query strings",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "url": "http://www.example.com/home",
         "experiments": [
           {
@@ -7812,7 +10299,10 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [0.1, 0.9],
+            "weights": [
+              0.1,
+              0.9
+            ],
             "variations": [
               {},
               {
@@ -7833,7 +10323,9 @@
     [
       "redirects with query string on original url and persistQueryString enabled",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "url": "http://www.example.com/home?color=blue&food=sushi",
         "experiments": [
           {
@@ -7845,7 +10337,10 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [0.1, 0.9],
+            "weights": [
+              0.1,
+              0.9
+            ],
             "variations": [
               {},
               {
@@ -7867,7 +10362,9 @@
     [
       "merges query strings on original url & redirect url with param conflicts correctly when persistQueryString enabled",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "url": "http://www.example.com/home?color=blue&food=sushi&title=original",
         "experiments": [
           {
@@ -7879,7 +10376,10 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [0.1, 0.9],
+            "weights": [
+              0.1,
+              0.9
+            ],
             "variations": [
               {},
               {
@@ -7901,7 +10401,9 @@
     [
       "only performs a redirect for first eligible experiment when there are multiple eligible experiments",
       {
-        "attributes": { "id": "1" },
+        "attributes": {
+          "id": "1"
+        },
         "url": "http://www.example.com/home",
         "experiments": [
           {
@@ -7913,7 +10415,10 @@
                 "pattern": "http://www.example.com/"
               }
             ],
-            "weights": [0.1, 0.9],
+            "weights": [
+              0.1,
+              0.9
+            ],
             "variations": [
               {},
               {
@@ -7930,7 +10435,10 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [0.1, 0.9],
+            "weights": [
+              0.1,
+              0.9
+            ],
             "variations": [
               {},
               {
@@ -7947,7 +10455,10 @@
                 "pattern": "http://www.example.com/home"
               }
             ],
-            "weights": [0.1, 0.9],
+            "weights": [
+              0.1,
+              0.9
+            ],
             "variations": [
               {},
               {

--- a/tests/scripts/corpus_skiplist.json
+++ b/tests/scripts/corpus_skiplist.json
@@ -1,9 +1,20 @@
 {
-  "_doc": "Skiplist for the corpus freshness check. Two buckets:\n  * \"missing\" — case names JS has and Python deliberately doesn't. Use when JS adds a case for a feature Python doesn't (yet) support.\n  * \"drift\"   — case names where Python deliberately keeps a different body from JS. Use sparingly — body-drift on a shared case is usually a bug.\nExtras (Python has, JS doesn't) are reported but never fail CI, so they don't need an entry here.\nAdd a brief reason in `_reasons` whenever you add an entry so future maintainers know why.",
-  "missing": {},
+  "_doc": "Skiplist for the corpus freshness check. Two buckets:\n  * \"missing\" \u2014 case names JS has and Python deliberately doesn't. Use when JS adds a case for a feature Python doesn't (yet) support.\n  * \"drift\"   \u2014 case names where Python deliberately keeps a different body from JS. Use sparingly \u2014 body-drift on a shared case is usually a bug.\nExtras (Python has, JS doesn't) are reported but never fail CI, so they don't need an entry here.\nAdd a brief reason in `_reasons` whenever you add an entry so future maintainers know why.",
+  "missing": {
+    "feature": [
+      "CB rule with empty contexts (explore) buckets on marginal weights with fallback leaf -1",
+      "CB rule with no contexts key falls back to marginal weights (fallback leaf -1)",
+      "CB rule with empty contexts uses marginal weights (fallback leaf -1)",
+      "CB rule with empty contexts is overridden by forced variation like a normal experiment"
+    ]
+  },
   "drift": {},
   "_reasons": {
     "_example_missing": "evalCondition::case name -> short reason (e.g. 'tests $someOperator that Python doesn't implement yet').",
-    "_example_drift":   "evalCondition::case name -> short reason (e.g. 'JS shipped a behavioral change in case X; Python intentionally kept the prior expectation pending review')."
+    "_example_drift": "evalCondition::case name -> short reason (e.g. 'JS shipped a behavioral change in case X; Python intentionally kept the prior expectation pending review').",
+    "feature::CB rule with empty contexts (explore) buckets on marginal weights with fallback leaf -1": "contextual bandit rules (spec 0.8.0: contextualBandits payload + contextualVariations) are not implemented in the Python SDK yet",
+    "feature::CB rule with no contexts key falls back to marginal weights (fallback leaf -1)": "contextual bandit rules (spec 0.8.0: contextualBandits payload + contextualVariations) are not implemented in the Python SDK yet",
+    "feature::CB rule with empty contexts uses marginal weights (fallback leaf -1)": "contextual bandit rules (spec 0.8.0: contextualBandits payload + contextualVariations) are not implemented in the Python SDK yet",
+    "feature::CB rule with empty contexts is overridden by forced variation like a normal experiment": "contextual bandit rules (spec 0.8.0: contextualBandits payload + contextualVariations) are not implemented in the Python SDK yet"
   }
 }


### PR DESCRIPTION
## Summary
The corpus-freshness CI job started failing on every PR: the JS SDK bumped its `cases.json` to specVersion 0.8.0 (Python's corpus tracks 0.7.1) and added 7 new `feature` cases for contextual bandits. 

## Test plan
- [x] `python3 tests/scripts/check_corpus_freshness.py` against current JS corpus — exit 0 (4 skipped-missing, documented)
- [x] Full suite: `pytest tests/ -q --ignore=tests/scripts` — 791 passed (3 new conformance cases run on both clients)

## Out of scope 
- Contextual bandit support (tracked by the skiplist reasons; needs its own design/issue)