### PR TITLE
feat: deferred tracking buffer and prerequisite exposure reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,14 @@ gb = GrowthBook(
 )
 ```
 
+The callback fires for every experiment assignment an evaluation makes — including assignments inside prerequisite features and passthrough (holdout / ramp control) variations — and `on_feature_usage` fires for every feature evaluated, prerequisites included.
+
+#### Deferred Tracking
+
+When the process evaluating features isn't the right place to send analytics from (for example, a server evaluating on behalf of client SDKs), leave `on_experiment_viewed` unset and the SDK buffers exposures instead. Read them with `get_deferred_tracking_calls()` — a list of `{"experiment", "result", "user"}` dicts in the same shape as the JavaScript SDK's deferred tracking calls, ready to forward to a client's `setDeferredTrackingCalls` — or replay them later with `set_tracking_callback(cb)`, which fires anything buffered. `set_deferred_tracking_calls(calls)` and `fire_deferred_tracking_calls()` cover the receiving side.
+
+With the async `GrowthBookClient`, the buffer lives on each `UserContext` you evaluate with: `user_context.get_deferred_tracking_calls()` after evaluating, so one request's exposures never mix with another's.
+
 #### Built-in Tracking Plugin
 
 For easier setup, you can use the built-in tracking plugin that automatically sends experiment and feature events to GrowthBook's data warehouse:

--- a/README.md
+++ b/README.md
@@ -471,13 +471,21 @@ gb = GrowthBook(
 )
 ```
 
-The callback fires for every unique experiment assignment an evaluation makes — including assignments inside prerequisite features and passthrough (holdout / ramp control) variations — and `on_feature_usage` fires for every feature evaluated, prerequisites included, once per evaluation (a prerequisite consulted by several rules is reported once).
+The callback fires once for each experiment a user is assigned to during an evaluation. That includes experiments that decide a prerequisite feature and passthrough variations (the control arm of a holdout or ramp), not just the experiment that produced the final value. Likewise, `on_feature_usage` fires for every feature evaluated along the way, prerequisites included, once per evaluation.
 
 #### Deferred Tracking
 
-When the process evaluating features isn't the right place to send analytics from (for example, a server evaluating on behalf of client SDKs), pass `defer_tracking=True` and leave `on_experiment_viewed` unset: exposures are buffered instead of dropped. Read them with `get_deferred_tracking_calls()` — a list of `{"experiment", "result", "user"}` dicts in the same shape as the JavaScript SDK's deferred tracking calls, ready to forward to a client's `setDeferredTrackingCalls` — or replay them later with `set_tracking_callback(cb)`, which fires anything buffered. `set_deferred_tracking_calls(calls)` and `fire_deferred_tracking_calls()` cover the receiving side. The buffer keeps one entry per unique assignment and grows for as long as the instance lives, so use one instance (or `UserContext`) per request.
+Sometimes the process evaluating features isn't the right place to send analytics from — for example a server that evaluates on behalf of browser or mobile clients, which then report their own exposures. For that, turn on `defer_tracking`: each exposure is buffered as a `{"experiment", "result", "user"}` dict — the same shape the JavaScript SDK uses — so you can hand the list straight to a client's `setDeferredTrackingCalls`. Buffering is independent of `on_experiment_viewed`; if you configure both, exposures are reported through both channels, so pick one.
 
-With the async `GrowthBookClient`, the buffer lives on each `UserContext` you evaluate with: create it with `UserContext(attributes=..., defer_tracking=True)` and read `user_context.get_deferred_tracking_calls()` after evaluating, so one request's exposures never mix with another's.
+```python
+gb = GrowthBook(attributes={"id": user_id}, defer_tracking=True)
+gb.eval_feature("my-feature")
+exposures = gb.get_deferred_tracking_calls()  # forward these to the client
+```
+
+The buffer keeps one entry per unique assignment and lives as long as the instance does, so use one instance per request. With the async `GrowthBookClient`, the buffer lives on each `UserContext` instead: create it with `UserContext(attributes=..., defer_tracking=True)` and read `user_context.get_deferred_tracking_calls()` after evaluating, so one request's exposures never mix with another's.
+
+On the receiving side, a `GrowthBook` with `on_experiment_viewed` set can load forwarded exposures with `set_deferred_tracking_calls(calls)` and send them through its callback with `fire_deferred_tracking_calls()`; each exposure is delivered with the user it was recorded for.
 
 #### Built-in Tracking Plugin
 

--- a/README.md
+++ b/README.md
@@ -471,13 +471,13 @@ gb = GrowthBook(
 )
 ```
 
-The callback fires for every experiment assignment an evaluation makes — including assignments inside prerequisite features and passthrough (holdout / ramp control) variations — and `on_feature_usage` fires for every feature evaluated, prerequisites included.
+The callback fires for every unique experiment assignment an evaluation makes — including assignments inside prerequisite features and passthrough (holdout / ramp control) variations — and `on_feature_usage` fires for every feature evaluated, prerequisites included, once per evaluation (a prerequisite consulted by several rules is reported once).
 
 #### Deferred Tracking
 
-When the process evaluating features isn't the right place to send analytics from (for example, a server evaluating on behalf of client SDKs), leave `on_experiment_viewed` unset and the SDK buffers exposures instead. Read them with `get_deferred_tracking_calls()` — a list of `{"experiment", "result", "user"}` dicts in the same shape as the JavaScript SDK's deferred tracking calls, ready to forward to a client's `setDeferredTrackingCalls` — or replay them later with `set_tracking_callback(cb)`, which fires anything buffered. `set_deferred_tracking_calls(calls)` and `fire_deferred_tracking_calls()` cover the receiving side.
+When the process evaluating features isn't the right place to send analytics from (for example, a server evaluating on behalf of client SDKs), pass `defer_tracking=True` and leave `on_experiment_viewed` unset: exposures are buffered instead of dropped. Read them with `get_deferred_tracking_calls()` — a list of `{"experiment", "result", "user"}` dicts in the same shape as the JavaScript SDK's deferred tracking calls, ready to forward to a client's `setDeferredTrackingCalls` — or replay them later with `set_tracking_callback(cb)`, which fires anything buffered. `set_deferred_tracking_calls(calls)` and `fire_deferred_tracking_calls()` cover the receiving side. The buffer keeps one entry per unique assignment and grows for as long as the instance lives, so use one instance (or `UserContext`) per request.
 
-With the async `GrowthBookClient`, the buffer lives on each `UserContext` you evaluate with: `user_context.get_deferred_tracking_calls()` after evaluating, so one request's exposures never mix with another's.
+With the async `GrowthBookClient`, the buffer lives on each `UserContext` you evaluate with: create it with `UserContext(attributes=..., defer_tracking=True)` and read `user_context.get_deferred_tracking_calls()` after evaluating, so one request's exposures never mix with another's.
 
 #### Built-in Tracking Plugin
 

--- a/growthbook/common_types.py
+++ b/growthbook/common_types.py
@@ -471,63 +471,44 @@ class UserContext:
     overrides: Dict[str, Any] = field(default_factory=dict)
     sticky_bucket_assignment_docs: Dict[str, Any] = field(default_factory=dict)
     skip_all_experiments: bool = False
-    # Buffer exposures when no tracking callback is configured instead of
-    # dropping them (see get_deferred_tracking_calls). Opt-in: the buffer is
-    # unbounded for as long as this context lives.
+    # Buffer exposures for forwarding (see get_deferred_tracking_calls).
     defer_tracking: bool = False
 
     def __post_init__(self) -> None:
-        # Not a dataclass field: excluded from asdict/replace/compare so
-        # contexts cloned per request start with an empty buffer.
         self._deferred_tracking_calls: Dict[str, Dict[str, Any]] = {}
 
     def defer_tracking_call(self, experiment: "Experiment[Any]", result: "Result[Any]") -> None:
         if not self.defer_tracking:
             return
-        key = tracking_dedupe_key(experiment, result)
-        if key in self._deferred_tracking_calls:
-            return
-        self._deferred_tracking_calls[key] = {
+        self._deferred_tracking_calls.setdefault(tracking_dedupe_key(experiment, result), {
             "experiment": experiment.to_dict(),
             "result": result.to_dict(),
             "user": {"attributes": dict(self.attributes), "url": self.url},
-        }
+        })
 
     def get_deferred_tracking_calls(self) -> List[Dict[str, Any]]:
-        """Buffered exposures in the JS SDK's TrackingData shape
-        ({experiment, result, user}), in first-seen order."""
+        """Buffered exposures as {experiment, result, user} dicts, in first-seen order."""
         return list(self._deferred_tracking_calls.values())
 
     def set_deferred_tracking_calls(self, calls: List[Dict[str, Any]]) -> None:
-        """Replace the buffer, skipping entries that cannot be rebuilt."""
-        buffered: Dict[str, Dict[str, Any]] = {}
+        self._deferred_tracking_calls = {}
         for call in calls:
-            try:
-                hydrated = tracking_call_from_dict(call)
-            except Exception:
-                continue
-            if hydrated is None:
-                continue
-            experiment, result = hydrated
-            buffered[tracking_dedupe_key(experiment, result)] = call
-        self._deferred_tracking_calls = buffered
+            hydrated = tracking_call_from_dict(call)
+            if hydrated is not None:
+                self._deferred_tracking_calls[tracking_dedupe_key(*hydrated)] = call
 
     def clear_deferred_tracking_calls(self) -> None:
         self._deferred_tracking_calls = {}
 
 
 def tracking_dedupe_key(experiment: "Experiment[Any]", result: "Result[Any]") -> str:
-    """Identifies an exposure by the same fields as the JS SDK's dedupe key,
-    with separators so distinct exposures cannot collide on field boundaries."""
     return "\x00".join(
         (result.hashAttribute, str(result.hashValue), experiment.key, str(result.variationId))
     )
 
 
 def tracking_call_from_dict(entry: Any) -> Optional[Tuple["Experiment[Any]", "Result[Any]"]]:
-    """Rebuild an (experiment, result) pair from the JS-shaped TrackingData
-    dict emitted by the remote-eval proxy and by get_deferred_tracking_calls.
-    Returns None for entries missing the experiment key or variations."""
+    """Rebuild an (experiment, result) pair from a {experiment, result} dict."""
     if not isinstance(entry, dict):
         return None
     exp_data = entry.get("experiment")
@@ -536,8 +517,7 @@ def tracking_call_from_dict(entry: Any) -> Optional[Tuple["Experiment[Any]", "Re
         return None
     if not isinstance(exp_data.get("key"), str) or not isinstance(exp_data.get("variations"), list):
         return None
-    # The JS shape carries key/name/passthrough flat on the result; Python's
-    # Result takes them via a nested `meta` dict.
+    # key/name/passthrough arrive flat on the result; Result takes them via meta.
     meta: Optional[VariationMeta] = res_data.get("meta")
     if meta is None:
         flat = cast(VariationMeta, {k: res_data[k] for k in ("key", "name", "passthrough") if k in res_data})
@@ -669,10 +649,7 @@ class EvaluationContext:
     # directly, letting the async client schedule persistence off the event loop.
     # None (the default) preserves the sync client's direct-call behavior.
     save_sticky_bucket_doc: Optional[Callable[[Dict[str, Any]], None]] = None
-    # Feature usage already reported during this evaluation, key -> value, so
-    # a prerequisite consulted by several rules is reported once unless its
-    # value changed.
-    reported_features: Dict[str, str] = field(default_factory=dict)
+    reported_features: Set[str] = field(default_factory=set)
 
 
 # ---------------------------------------------------------------------------

--- a/growthbook/common_types.py
+++ b/growthbook/common_types.py
@@ -471,13 +471,19 @@ class UserContext:
     overrides: Dict[str, Any] = field(default_factory=dict)
     sticky_bucket_assignment_docs: Dict[str, Any] = field(default_factory=dict)
     skip_all_experiments: bool = False
-    # Exposures buffered while no tracking callback is configured, keyed by
-    # tracking_dedupe_key, for callers that forward tracking elsewhere.
-    _deferred_tracking_calls: Dict[str, Dict[str, Any]] = field(
-        default_factory=dict, init=False, repr=False, compare=False
-    )
+    # Buffer exposures when no tracking callback is configured instead of
+    # dropping them (see get_deferred_tracking_calls). Opt-in: the buffer is
+    # unbounded for as long as this context lives.
+    defer_tracking: bool = False
+
+    def __post_init__(self) -> None:
+        # Not a dataclass field: excluded from asdict/replace/compare so
+        # contexts cloned per request start with an empty buffer.
+        self._deferred_tracking_calls: Dict[str, Dict[str, Any]] = {}
 
     def defer_tracking_call(self, experiment: "Experiment[Any]", result: "Result[Any]") -> None:
+        if not self.defer_tracking:
+            return
         key = tracking_dedupe_key(experiment, result)
         if key in self._deferred_tracking_calls:
             return
@@ -493,13 +499,18 @@ class UserContext:
         return list(self._deferred_tracking_calls.values())
 
     def set_deferred_tracking_calls(self, calls: List[Dict[str, Any]]) -> None:
-        self._deferred_tracking_calls = {}
+        """Replace the buffer, skipping entries that cannot be rebuilt."""
+        buffered: Dict[str, Dict[str, Any]] = {}
         for call in calls:
-            hydrated = tracking_call_from_dict(call)
+            try:
+                hydrated = tracking_call_from_dict(call)
+            except Exception:
+                continue
             if hydrated is None:
                 continue
             experiment, result = hydrated
-            self._deferred_tracking_calls[tracking_dedupe_key(experiment, result)] = call
+            buffered[tracking_dedupe_key(experiment, result)] = call
+        self._deferred_tracking_calls = buffered
 
     def clear_deferred_tracking_calls(self) -> None:
         self._deferred_tracking_calls = {}
@@ -513,13 +524,17 @@ def tracking_dedupe_key(experiment: "Experiment[Any]", result: "Result[Any]") ->
     )
 
 
-def tracking_call_from_dict(entry: Dict[str, Any]) -> Optional[Tuple["Experiment[Any]", "Result[Any]"]]:
+def tracking_call_from_dict(entry: Any) -> Optional[Tuple["Experiment[Any]", "Result[Any]"]]:
     """Rebuild an (experiment, result) pair from the JS-shaped TrackingData
     dict emitted by the remote-eval proxy and by get_deferred_tracking_calls.
     Returns None for entries missing the experiment key or variations."""
-    exp_data = entry.get("experiment") or {}
-    res_data = entry.get("result") or {}
-    if "key" not in exp_data or "variations" not in exp_data:
+    if not isinstance(entry, dict):
+        return None
+    exp_data = entry.get("experiment")
+    res_data = entry.get("result")
+    if not isinstance(exp_data, dict) or not isinstance(res_data, dict):
+        return None
+    if not isinstance(exp_data.get("key"), str) or not isinstance(exp_data.get("variations"), list):
         return None
     # The JS shape carries key/name/passthrough flat on the result; Python's
     # Result takes them via a nested `meta` dict.

--- a/growthbook/common_types.py
+++ b/growthbook/common_types.py
@@ -17,6 +17,7 @@ from typing import (
     Union,
     Set,
     Tuple,
+    cast,
 )
 from enum import Enum
 from abc import ABC, abstractmethod
@@ -470,6 +471,76 @@ class UserContext:
     overrides: Dict[str, Any] = field(default_factory=dict)
     sticky_bucket_assignment_docs: Dict[str, Any] = field(default_factory=dict)
     skip_all_experiments: bool = False
+    # Exposures buffered while no tracking callback is configured, keyed by
+    # tracking_dedupe_key, for callers that forward tracking elsewhere.
+    _deferred_tracking_calls: Dict[str, Dict[str, Any]] = field(
+        default_factory=dict, init=False, repr=False, compare=False
+    )
+
+    def defer_tracking_call(self, experiment: "Experiment[Any]", result: "Result[Any]") -> None:
+        key = tracking_dedupe_key(experiment, result)
+        if key in self._deferred_tracking_calls:
+            return
+        self._deferred_tracking_calls[key] = {
+            "experiment": experiment.to_dict(),
+            "result": result.to_dict(),
+            "user": {"attributes": dict(self.attributes), "url": self.url},
+        }
+
+    def get_deferred_tracking_calls(self) -> List[Dict[str, Any]]:
+        """Buffered exposures in the JS SDK's TrackingData shape
+        ({experiment, result, user}), in first-seen order."""
+        return list(self._deferred_tracking_calls.values())
+
+    def set_deferred_tracking_calls(self, calls: List[Dict[str, Any]]) -> None:
+        self._deferred_tracking_calls = {}
+        for call in calls:
+            hydrated = tracking_call_from_dict(call)
+            if hydrated is None:
+                continue
+            experiment, result = hydrated
+            self._deferred_tracking_calls[tracking_dedupe_key(experiment, result)] = call
+
+    def clear_deferred_tracking_calls(self) -> None:
+        self._deferred_tracking_calls = {}
+
+
+def tracking_dedupe_key(experiment: "Experiment[Any]", result: "Result[Any]") -> str:
+    """Identifies an exposure by the same fields as the JS SDK's dedupe key,
+    with separators so distinct exposures cannot collide on field boundaries."""
+    return "\x00".join(
+        (result.hashAttribute, str(result.hashValue), experiment.key, str(result.variationId))
+    )
+
+
+def tracking_call_from_dict(entry: Dict[str, Any]) -> Optional[Tuple["Experiment[Any]", "Result[Any]"]]:
+    """Rebuild an (experiment, result) pair from the JS-shaped TrackingData
+    dict emitted by the remote-eval proxy and by get_deferred_tracking_calls.
+    Returns None for entries missing the experiment key or variations."""
+    exp_data = entry.get("experiment") or {}
+    res_data = entry.get("result") or {}
+    if "key" not in exp_data or "variations" not in exp_data:
+        return None
+    # The JS shape carries key/name/passthrough flat on the result; Python's
+    # Result takes them via a nested `meta` dict.
+    meta: Optional[VariationMeta] = res_data.get("meta")
+    if meta is None:
+        flat = cast(VariationMeta, {k: res_data[k] for k in ("key", "name", "passthrough") if k in res_data})
+        meta = flat or None
+    experiment: Experiment[Any] = Experiment(**exp_data)
+    result: Result[Any] = Result(
+        variationId=res_data.get("variationId", 0),
+        inExperiment=res_data.get("inExperiment", False),
+        value=res_data.get("value"),
+        hashUsed=res_data.get("hashUsed", False),
+        hashAttribute=res_data.get("hashAttribute", "id"),
+        hashValue=res_data.get("hashValue", ""),
+        featureId=res_data.get("featureId"),
+        meta=meta,
+        bucket=res_data.get("bucket"),
+        stickyBucketUsed=res_data.get("stickyBucketUsed", False),
+    )
+    return experiment, result
 
 
 class TrackingCallback(Protocol):
@@ -583,6 +654,10 @@ class EvaluationContext:
     # directly, letting the async client schedule persistence off the event loop.
     # None (the default) preserves the sync client's direct-call behavior.
     save_sticky_bucket_doc: Optional[Callable[[Dict[str, Any]], None]] = None
+    # Feature usage already reported during this evaluation, key -> value, so
+    # a prerequisite consulted by several rules is reported once unless its
+    # value changed.
+    reported_features: Dict[str, str] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------

--- a/growthbook/core.py
+++ b/growthbook/core.py
@@ -560,7 +560,10 @@ def _report_feature_usage(
     evalContext: EvaluationContext,
     feature_usage_cb: FeatureUsageCb,
 ) -> None:
-    stringified = json.dumps(result.value, sort_keys=True, default=str)
+    try:
+        stringified = json.dumps(result.value, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        stringified = repr(result.value)
     if evalContext.reported_features.get(key) == stringified:
         return
     evalContext.reported_features[key] = stringified
@@ -616,6 +619,7 @@ def _eval_feature(
             prereq_res = eval_prereqs(
                 parentConditions=rule.parentConditions,
                 evalContext=evalContext,
+                callback_subscription=callback_subscription,
                 tracking_cb=tracking_cb,
                 feature_usage_cb=feature_usage_cb,
             )
@@ -722,6 +726,7 @@ def _eval_feature(
 def eval_prereqs(
     parentConditions: List[Dict[str, Any]],
     evalContext: EvaluationContext,
+    callback_subscription: Optional[Callable[[Experiment[Any], Result[Any]], None]] = None,
     tracking_cb: Optional[Callable[[Experiment[Any], Result[Any], UserContext], None]] = None,
     feature_usage_cb: Optional[FeatureUsageCb] = None,
 ) -> str:
@@ -738,6 +743,7 @@ def eval_prereqs(
         parentRes = eval_feature(
             key=parent_id,
             evalContext=evalContext,
+            callback_subscription=callback_subscription,
             tracking_cb=tracking_cb,
             feature_usage_cb=feature_usage_cb,
         )

--- a/growthbook/core.py
+++ b/growthbook/core.py
@@ -695,6 +695,7 @@ def _eval_feature(
             evalContext=evalContext,
             tracking_cb=tracking_cb,
             feature_usage_cb=feature_usage_cb,
+            callback_subscription=callback_subscription,
         )
 
         if callback_subscription:
@@ -840,6 +841,7 @@ def run_experiment(experiment: Experiment[Any],
                    evalContext: Optional[EvaluationContext] = None,
                    tracking_cb: Optional[Callable[[Experiment[Any], Result[Any], UserContext], None]] = None,
                    feature_usage_cb: Optional[FeatureUsageCb] = None,
+                   callback_subscription: Optional[Callable[[Experiment[Any], Result[Any]], None]] = None,
                 ) -> Result[Any]:
     if evalContext is None:
         raise ValueError("evalContext is required - run_experiment")
@@ -957,6 +959,7 @@ def run_experiment(experiment: Experiment[Any],
             prereq_res = eval_prereqs(
                 parentConditions=experiment.parentConditions,
                 evalContext=evalContext,
+                callback_subscription=callback_subscription,
                 tracking_cb=tracking_cb,
                 feature_usage_cb=feature_usage_cb,
             )

--- a/growthbook/core.py
+++ b/growthbook/core.py
@@ -560,13 +560,9 @@ def _report_feature_usage(
     evalContext: EvaluationContext,
     feature_usage_cb: FeatureUsageCb,
 ) -> None:
-    try:
-        stringified = json.dumps(result.value, sort_keys=True, default=str)
-    except (TypeError, ValueError):
-        stringified = repr(result.value)
-    if evalContext.reported_features.get(key) == stringified:
+    if key in evalContext.reported_features:
         return
-    evalContext.reported_features[key] = stringified
+    evalContext.reported_features.add(key)
     feature_usage_cb(key, result, evalContext.user)
 
 
@@ -577,8 +573,7 @@ def eval_feature(
     tracking_cb: Optional[Callable[[Experiment[Any], Result[Any], UserContext], None]] = None,
     feature_usage_cb: Optional[FeatureUsageCb] = None,
 ) -> FeatureResult[Any]:
-    """Core feature evaluation logic as a standalone function. Feature usage
-    is reported for every feature evaluated, prerequisites included."""
+    """Core feature evaluation logic as a standalone function"""
 
     if evalContext is None:
         raise ValueError("evalContext is required - eval_feature")

--- a/growthbook/core.py
+++ b/growthbook/core.py
@@ -6,8 +6,17 @@ import json
 from functools import lru_cache
 
 from urllib.parse import urlparse, parse_qs
-from typing import Callable, Optional, Any, Set, Tuple, List, Dict, cast
-from .common_types import EvaluationContext, FeatureResult, Experiment, Filter, Result, UserContext, VariationMeta
+from typing import Callable, Optional, Any, Set, Tuple, List, Dict
+from .common_types import (
+    EvaluationContext,
+    FeatureResult,
+    Experiment,
+    Filter,
+    Result,
+    UserContext,
+    VariationMeta,
+    tracking_call_from_dict,
+)
 
 
 logger = logging.getLogger("growthbook.core")
@@ -531,50 +540,60 @@ def _fire_rule_tracks(
     if not rule_tracks or not tracking_cb:
         return
     for entry in rule_tracks:
-        exp_data = entry.get("experiment") or {}
-        res_data = entry.get("result") or {}
-        # Experiment requires at minimum a key and variations list.
-        if "key" not in exp_data or "variations" not in exp_data:
-            logger.debug("Skipping rule.tracks entry: missing experiment key/variations")
-            continue
-        # The proxy emits Result in the JS shape: key/name/passthrough flat at
-        # the top level. Python's Result takes those via a nested `meta` dict.
-        # Re-pack if no explicit `meta` was provided.
-        meta: Optional[VariationMeta] = res_data.get("meta")
-        if meta is None:
-            flat = cast(VariationMeta, {k: res_data[k] for k in ("key", "name", "passthrough") if k in res_data})
-            meta = flat or None
         try:
-            # Experiment accepts **_ignored, so passing the raw proxy dict is safe.
-            experiment = Experiment(**exp_data)
-            result = Result(
-                variationId=res_data.get("variationId", 0),
-                inExperiment=res_data.get("inExperiment", False),
-                value=res_data.get("value"),
-                hashUsed=res_data.get("hashUsed", False),
-                hashAttribute=res_data.get("hashAttribute", "id"),
-                hashValue=res_data.get("hashValue", ""),
-                featureId=res_data.get("featureId"),
-                meta=meta,
-                bucket=res_data.get("bucket"),
-                stickyBucketUsed=res_data.get("stickyBucketUsed", False),
-            )
+            hydrated = tracking_call_from_dict(entry)
+            if hydrated is None:
+                logger.debug("Skipping rule.tracks entry: missing experiment key/variations")
+                continue
+            experiment, result = hydrated
             tracking_cb(experiment, result, eval_context.user)
         except Exception:
             logger.exception("Failed to fire rule.tracks tracking event")
+
+
+FeatureUsageCb = Callable[[str, FeatureResult[Any], UserContext], None]
+
+
+def _report_feature_usage(
+    key: str,
+    result: FeatureResult[Any],
+    evalContext: EvaluationContext,
+    feature_usage_cb: FeatureUsageCb,
+) -> None:
+    stringified = json.dumps(result.value, sort_keys=True, default=str)
+    if evalContext.reported_features.get(key) == stringified:
+        return
+    evalContext.reported_features[key] = stringified
+    feature_usage_cb(key, result, evalContext.user)
 
 
 def eval_feature(
     key: str,
     evalContext: Optional[EvaluationContext] = None,
     callback_subscription: Optional[Callable[[Experiment[Any], Result[Any]], None]] = None,
-    tracking_cb: Optional[Callable[[Experiment[Any], Result[Any], UserContext], None]] = None
+    tracking_cb: Optional[Callable[[Experiment[Any], Result[Any], UserContext], None]] = None,
+    feature_usage_cb: Optional[FeatureUsageCb] = None,
 ) -> FeatureResult[Any]:
-    """Core feature evaluation logic as a standalone function"""
+    """Core feature evaluation logic as a standalone function. Feature usage
+    is reported for every feature evaluated, prerequisites included."""
 
     if evalContext is None:
         raise ValueError("evalContext is required - eval_feature")
-    
+
+    result = _eval_feature(key, evalContext, callback_subscription, tracking_cb, feature_usage_cb)
+    if feature_usage_cb:
+        _report_feature_usage(key, result, evalContext, feature_usage_cb)
+    return result
+
+
+def _eval_feature(
+    key: str,
+    evalContext: EvaluationContext,
+    callback_subscription: Optional[Callable[[Experiment[Any], Result[Any]], None]],
+    tracking_cb: Optional[Callable[[Experiment[Any], Result[Any], UserContext], None]],
+    feature_usage_cb: Optional[FeatureUsageCb],
+) -> FeatureResult[Any]:
+
     if key not in evalContext.global_ctx.features:
         logger.warning("Unknown feature %s", key)
         return FeatureResult(None, "unknownFeature")
@@ -594,7 +613,12 @@ def eval_feature(
         evalContext.stack.evaluated_features = evaluated_features.copy()
 
         if (rule.parentConditions):
-            prereq_res = eval_prereqs(parentConditions=rule.parentConditions, evalContext=evalContext)
+            prereq_res = eval_prereqs(
+                parentConditions=rule.parentConditions,
+                evalContext=evalContext,
+                tracking_cb=tracking_cb,
+                feature_usage_cb=feature_usage_cb,
+            )
             if prereq_res == "gate":
                 logger.debug("Top-level prerequisite failed, return None, feature %s", key)
                 return FeatureResult(None, "prerequisite")
@@ -666,7 +690,13 @@ def eval_feature(
             minBucketVersion=rule.minBucketVersion,
         )
 
-        result = run_experiment(experiment=exp, featureId=key, evalContext=evalContext, tracking_cb=tracking_cb)
+        result = run_experiment(
+            experiment=exp,
+            featureId=key,
+            evalContext=evalContext,
+            tracking_cb=tracking_cb,
+            feature_usage_cb=feature_usage_cb,
+        )
 
         if callback_subscription:
             callback_subscription(exp, result)
@@ -689,7 +719,12 @@ def eval_feature(
     logger.debug("Use default value for feature %s", key)
     return FeatureResult(feature.defaultValue, "defaultValue")
 
-def eval_prereqs(parentConditions: List[Dict[str, Any]], evalContext: EvaluationContext) -> str:
+def eval_prereqs(
+    parentConditions: List[Dict[str, Any]],
+    evalContext: EvaluationContext,
+    tracking_cb: Optional[Callable[[Experiment[Any], Result[Any], UserContext], None]] = None,
+    feature_usage_cb: Optional[FeatureUsageCb] = None,
+) -> str:
     evaluated_features = evalContext.stack.evaluated_features.copy()
 
     for parentCondition in parentConditions:
@@ -699,8 +734,13 @@ def eval_prereqs(parentConditions: List[Dict[str, Any]], evalContext: Evaluation
         parent_id = parentCondition.get("id")
         if parent_id is None:
             continue  # Skip if no valid ID
-            
-        parentRes = eval_feature(key=parent_id, evalContext=evalContext)
+
+        parentRes = eval_feature(
+            key=parent_id,
+            evalContext=evalContext,
+            tracking_cb=tracking_cb,
+            feature_usage_cb=feature_usage_cb,
+        )
 
         if parentRes.source == "cyclicPrerequisite":
             return "cyclic"
@@ -797,7 +837,8 @@ def _get_sticky_bucket_variation(
 def run_experiment(experiment: Experiment[Any],
                    featureId: Optional[str] = None,
                    evalContext: Optional[EvaluationContext] = None,
-                   tracking_cb: Optional[Callable[[Experiment[Any], Result[Any], UserContext], None]] = None
+                   tracking_cb: Optional[Callable[[Experiment[Any], Result[Any], UserContext], None]] = None,
+                   feature_usage_cb: Optional[FeatureUsageCb] = None,
                 ) -> Result[Any]:
     if evalContext is None:
         raise ValueError("evalContext is required - run_experiment")
@@ -912,7 +953,12 @@ def run_experiment(experiment: Experiment[Any],
 
         # 8.05 Exclude if parent conditions are not met
         if (experiment.parentConditions):
-            prereq_res = eval_prereqs(parentConditions=experiment.parentConditions, evalContext=evalContext)
+            prereq_res = eval_prereqs(
+                parentConditions=experiment.parentConditions,
+                evalContext=evalContext,
+                tracking_cb=tracking_cb,
+                feature_usage_cb=feature_usage_cb,
+            )
             if prereq_res == "gate" or prereq_res == "fail":
                 logger.debug("Skip experiment %s because of failing prerequisite", experiment.key)
                 return _getExperimentResult(experiment=experiment, featureId=featureId, evalContext=evalContext)

--- a/growthbook/growthbook.py
+++ b/growthbook/growthbook.py
@@ -35,6 +35,8 @@ from .common_types import (
     AbstractStickyBucketService,
     AbstractAsyncStickyBucketService,
     FeatureRule,
+    tracking_call_from_dict,
+    tracking_dedupe_key,
     build_remote_eval_payload,
     features_from_dict,
     validate_remote_eval_options,
@@ -1251,6 +1253,7 @@ class GrowthBook(object):
         try:
             self._subscriptions.clear()
             self._tracked.clear()
+            self._user_ctx.clear_deferred_tracking_calls()
             self._assigned.clear()
             self._trackingCallback = None
             self._featureUsageCallback = None
@@ -1384,18 +1387,20 @@ class GrowthBook(object):
         return self._build_eval_context()
 
     def eval_feature(self, key: str) -> FeatureResult[Any]:
-        result = core_eval_feature(key=key, 
-                                   evalContext=self._get_eval_context(), 
-                                   callback_subscription=self._fireSubscriptions,
-                                   tracking_cb=self._track
-                                   )
-        # Call feature usage callback if provided
-        if self._featureUsageCallback:
-            try:
-                self._featureUsageCallback(key, result, self._user_ctx)
-            except Exception:
-                pass
-        return result
+        return core_eval_feature(key=key,
+                                 evalContext=self._get_eval_context(),
+                                 callback_subscription=self._fireSubscriptions,
+                                 tracking_cb=self._track,
+                                 feature_usage_cb=self._report_feature_usage,
+                                 )
+
+    def _report_feature_usage(self, key: str, result: FeatureResult[Any], user_context: UserContext) -> None:
+        if not self._featureUsageCallback:
+            return
+        try:
+            self._featureUsageCallback(key, result, user_context)
+        except Exception:
+            pass
 
     @deprecated("getAllResults is deprecated, use get_all_results instead")
     def getAllResults(self) -> Dict[str, Dict[str, Any]]:
@@ -1426,7 +1431,8 @@ class GrowthBook(object):
         # result = self._run(experiment)
         result = run_experiment(experiment=experiment,
                                 evalContext=self._get_eval_context(),
-                                tracking_cb=self._track
+                                tracking_cb=self._track,
+                                feature_usage_cb=self._report_feature_usage,
                                 )
 
         self._fireSubscriptions(experiment, result)
@@ -1438,19 +1444,44 @@ class GrowthBook(object):
 
     def _track(self, experiment: Experiment[Any], result: Result[Any], user_context: UserContext) -> None:
         if not self._trackingCallback:
+            user_context.defer_tracking_call(experiment, result)
             return None
-        key = (
-            result.hashAttribute
-            + str(result.hashValue)
-            + experiment.key
-            + str(result.variationId)
-        )
+        key = tracking_dedupe_key(experiment, result)
         if not self._tracked.get(key):
             try:
                 self._trackingCallback(experiment=experiment, result=result, user_context=user_context)
                 self._tracked[key] = True
             except Exception as e:
                 logger.exception(e)
+
+    def set_tracking_callback(self, callback: Optional[TrackingCallback]) -> None:
+        """Set the tracking callback and fire any exposures buffered while
+        none was configured."""
+        self._trackingCallback = callback
+        self.fire_deferred_tracking_calls()
+
+    def get_deferred_tracking_calls(self) -> List[Dict[str, Any]]:
+        """Exposures buffered while no tracking callback was configured, in
+        the JS SDK's TrackingData shape ({experiment, result, user}) — ready
+        to forward to a client SDK's set_deferred_tracking_calls."""
+        return self._user_ctx.get_deferred_tracking_calls()
+
+    def set_deferred_tracking_calls(self, calls: List[Dict[str, Any]]) -> None:
+        self._user_ctx.set_deferred_tracking_calls(calls)
+
+    def fire_deferred_tracking_calls(self) -> None:
+        """Send buffered exposures through the tracking callback and empty
+        the buffer. No-op without a tracking callback."""
+        if not self._trackingCallback:
+            return
+        calls = self._user_ctx.get_deferred_tracking_calls()
+        self._user_ctx.clear_deferred_tracking_calls()
+        for call in calls:
+            hydrated = tracking_call_from_dict(call)
+            if hydrated is None:
+                continue
+            experiment, result = hydrated
+            self._track(experiment, result, self._user_ctx)
 
     def _derive_sticky_bucket_identifier_attributes(self) -> List[str]:
         attributes = set()

--- a/growthbook/growthbook.py
+++ b/growthbook/growthbook.py
@@ -880,6 +880,7 @@ class GrowthBook(object):
         stale_ttl: int = 300,  # 5 minutes default
         plugins: Optional[List["PluginLike"]] = None,
         skip_all_experiments: bool = False,
+        defer_tracking: bool = False,
         # Deprecated args (camelCase spellings fold into their snake_case
         # equivalents above; the snake_case value wins when both are given)
         trackingCallback: Optional[TrackingCallback] = None,
@@ -985,7 +986,8 @@ class GrowthBook(object):
             forced_features=self._forcedFeatures,
             overrides=self._overrides,
             sticky_bucket_assignment_docs=self._sticky_bucket_assignment_docs,
-            skip_all_experiments=self._skip_all_experiments
+            skip_all_experiments=self._skip_all_experiments,
+            defer_tracking=defer_tracking,
         )
 
         if features:
@@ -1391,16 +1393,21 @@ class GrowthBook(object):
                                  evalContext=self._get_eval_context(),
                                  callback_subscription=self._fireSubscriptions,
                                  tracking_cb=self._track,
-                                 feature_usage_cb=self._report_feature_usage,
+                                 feature_usage_cb=self._feature_usage_cb(),
                                  )
 
-    def _report_feature_usage(self, key: str, result: FeatureResult[Any], user_context: UserContext) -> None:
+    def _feature_usage_cb(self) -> Optional[FeatureUsageCallback]:
         if not self._featureUsageCallback:
-            return
-        try:
-            self._featureUsageCallback(key, result, user_context)
-        except Exception:
-            pass
+            return None
+        cb = self._featureUsageCallback
+
+        def report(key: str, result: FeatureResult[Any], user_context: UserContext) -> None:
+            try:
+                cb(key, result, user_context)
+            except Exception:
+                pass
+
+        return report
 
     @deprecated("getAllResults is deprecated, use get_all_results instead")
     def getAllResults(self) -> Dict[str, Dict[str, Any]]:
@@ -1432,7 +1439,7 @@ class GrowthBook(object):
         result = run_experiment(experiment=experiment,
                                 evalContext=self._get_eval_context(),
                                 tracking_cb=self._track,
-                                feature_usage_cb=self._report_feature_usage,
+                                feature_usage_cb=self._feature_usage_cb(),
                                 )
 
         self._fireSubscriptions(experiment, result)
@@ -1470,18 +1477,29 @@ class GrowthBook(object):
         self._user_ctx.set_deferred_tracking_calls(calls)
 
     def fire_deferred_tracking_calls(self) -> None:
-        """Send buffered exposures through the tracking callback and empty
-        the buffer. No-op without a tracking callback."""
-        if not self._trackingCallback:
+        """Send buffered exposures through the tracking callback. Entries the
+        callback raises on stay buffered; the rest are removed. No-op without
+        a tracking callback."""
+        callback = self._trackingCallback
+        if not callback:
             return
-        calls = self._user_ctx.get_deferred_tracking_calls()
-        self._user_ctx.clear_deferred_tracking_calls()
-        for call in calls:
+        failed: List[Dict[str, Any]] = []
+        for call in self._user_ctx.get_deferred_tracking_calls():
             hydrated = tracking_call_from_dict(call)
             if hydrated is None:
                 continue
             experiment, result = hydrated
-            self._track(experiment, result, self._user_ctx)
+            # Replay with the user the exposure was buffered for, not whoever
+            # the instance currently represents.
+            user = call.get("user") or {}
+            snapshot = UserContext(attributes=dict(user.get("attributes") or {}), url=user.get("url") or "")
+            try:
+                callback(experiment=experiment, result=result, user_context=snapshot)
+                self._tracked[tracking_dedupe_key(experiment, result)] = True
+            except Exception as e:
+                logger.exception(e)
+                failed.append(call)
+        self._user_ctx.set_deferred_tracking_calls(failed)
 
     def _derive_sticky_bucket_identifier_attributes(self) -> List[str]:
         attributes = set()

--- a/growthbook/growthbook.py
+++ b/growthbook/growthbook.py
@@ -1450,8 +1450,8 @@ class GrowthBook(object):
         return lambda: self._subscriptions.remove(callback)
 
     def _track(self, experiment: Experiment[Any], result: Result[Any], user_context: UserContext) -> None:
+        user_context.defer_tracking_call(experiment, result)
         if not self._trackingCallback:
-            user_context.defer_tracking_call(experiment, result)
             return None
         key = tracking_dedupe_key(experiment, result)
         if not self._tracked.get(key):
@@ -1461,45 +1461,39 @@ class GrowthBook(object):
             except Exception as e:
                 logger.exception(e)
 
-    def set_tracking_callback(self, callback: Optional[TrackingCallback]) -> None:
-        """Set the tracking callback and fire any exposures buffered while
-        none was configured."""
-        self._trackingCallback = callback
-        self.fire_deferred_tracking_calls()
-
     def get_deferred_tracking_calls(self) -> List[Dict[str, Any]]:
-        """Exposures buffered while no tracking callback was configured, in
-        the JS SDK's TrackingData shape ({experiment, result, user}) — ready
-        to forward to a client SDK's set_deferred_tracking_calls."""
+        """Exposures buffered with defer_tracking, as {experiment, result, user} dicts."""
         return self._user_ctx.get_deferred_tracking_calls()
 
     def set_deferred_tracking_calls(self, calls: List[Dict[str, Any]]) -> None:
         self._user_ctx.set_deferred_tracking_calls(calls)
 
     def fire_deferred_tracking_calls(self) -> None:
-        """Send buffered exposures through the tracking callback. Entries the
-        callback raises on stay buffered; the rest are removed. No-op without
-        a tracking callback."""
+        """Send buffered exposures through the tracking callback, each with the
+        user it was buffered for. Entries the callback raises on stay buffered."""
         callback = self._trackingCallback
         if not callback:
             return
-        failed: List[Dict[str, Any]] = []
-        for call in self._user_ctx.get_deferred_tracking_calls():
+        buffer = self._user_ctx._deferred_tracking_calls
+        for key, call in list(buffer.items()):
             hydrated = tracking_call_from_dict(call)
             if hydrated is None:
+                buffer.pop(key, None)
                 continue
             experiment, result = hydrated
-            # Replay with the user the exposure was buffered for, not whoever
-            # the instance currently represents.
             user = call.get("user") or {}
-            snapshot = UserContext(attributes=dict(user.get("attributes") or {}), url=user.get("url") or "")
+            attributes = user.get("attributes")
+            snapshot = UserContext(
+                attributes=dict(attributes) if isinstance(attributes, dict) else {},
+                url=user.get("url") or "",
+            )
             try:
                 callback(experiment=experiment, result=result, user_context=snapshot)
-                self._tracked[tracking_dedupe_key(experiment, result)] = True
             except Exception as e:
                 logger.exception(e)
-                failed.append(call)
-        self._user_ctx.set_deferred_tracking_calls(failed)
+                continue
+            self._tracked[key] = True
+            buffer.pop(key, None)
 
     def _derive_sticky_bucket_identifier_attributes(self) -> List[str]:
         attributes = set()

--- a/growthbook/growthbook.py
+++ b/growthbook/growthbook.py
@@ -1440,6 +1440,7 @@ class GrowthBook(object):
                                 evalContext=self._get_eval_context(),
                                 tracking_cb=self._track,
                                 feature_usage_cb=self._feature_usage_cb(),
+                                callback_subscription=self._fireSubscriptions,
                                 )
 
         self._fireSubscriptions(experiment, result)
@@ -1481,7 +1482,9 @@ class GrowthBook(object):
                 buffer.pop(key, None)
                 continue
             experiment, result = hydrated
-            user = call.get("user") or {}
+            user = call.get("user")
+            if not isinstance(user, dict):
+                user = {}
             attributes = user.get("attributes")
             snapshot = UserContext(
                 attributes=dict(attributes) if isinstance(attributes, dict) else {},

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -736,8 +736,8 @@ class GrowthBookClient:
 
     def _track(self, experiment: Experiment[Any], result: Result[Any], user_context: UserContext) -> None:
         """Thread-safe tracking implementation"""
+        user_context.defer_tracking_call(experiment, result)
         if not self.options.on_experiment_viewed:
-            user_context.defer_tracking_call(experiment, result)
             return
 
         key = tracking_dedupe_key(experiment, result)

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -1217,20 +1217,21 @@ class GrowthBookClient:
             key=key,
             evalContext=context,
             tracking_cb=self._track,
-            feature_usage_cb=self._report_feature_usage,
+            feature_usage_cb=self._feature_usage_cb(),
         )
 
-    def _report_feature_usage(self, key: str, result: FeatureResult[Any], user_context: UserContext) -> None:
+    def _feature_usage_cb(self) -> Optional[Callable[[str, FeatureResult[Any], UserContext], None]]:
         if not self.options.on_feature_usage:
-            return
-        try:
-            self._run_user_callback(
-                self.options.on_feature_usage,
-                (key, result, user_context),
-                "feature usage",
-            )
-        except Exception:
-            logger.exception("Error in feature usage callback")
+            return None
+        cb = self.options.on_feature_usage
+
+        def report(key: str, result: FeatureResult[Any], user_context: UserContext) -> None:
+            try:
+                self._run_user_callback(cb, (key, result, user_context), "feature usage")
+            except Exception:
+                logger.exception("Error in feature usage callback")
+
+        return report
 
     async def is_on(self, key: str, user_context: UserContext) -> bool:
         """Check if a feature is enabled with proper async context management"""
@@ -1253,7 +1254,7 @@ class GrowthBookClient:
             experiment=experiment,
             evalContext=context,
             tracking_cb=self._track,
-            feature_usage_cb=self._report_feature_usage,
+            feature_usage_cb=self._feature_usage_cb(),
         )
         # Fire subscriptions synchronously
         self._fire_subscriptions(experiment, result)

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -33,6 +33,7 @@ from .common_types import (
     FeatureResult,
     FeatureRefreshStrategy,
     AbstractAsyncStickyBucketService,
+    tracking_dedupe_key,
     Experiment,
     build_remote_eval_payload,
     features_from_dict,
@@ -736,15 +737,10 @@ class GrowthBookClient:
     def _track(self, experiment: Experiment[Any], result: Result[Any], user_context: UserContext) -> None:
         """Thread-safe tracking implementation"""
         if not self.options.on_experiment_viewed:
+            user_context.defer_tracking_call(experiment, result)
             return
 
-        # Create unique key for this tracking event
-        key = (
-            result.hashAttribute
-            + str(result.hashValue)
-            + experiment.key
-            + str(result.variationId)
-        )
+        key = tracking_dedupe_key(experiment, result)
 
         with self._tracked_lock:
             if not self._tracked.get(key):
@@ -1217,18 +1213,24 @@ class GrowthBookClient:
         immutable feature snapshot, so concurrent evaluations never contend
         with each other or with feature updates."""
         context = await self.create_evaluation_context(user_context)
-        result = core_eval_feature(key=key, evalContext=context, tracking_cb=self._track)
-        # Call feature usage callback if provided
-        if self.options.on_feature_usage:
-            try:
-                self._run_user_callback(
-                    self.options.on_feature_usage,
-                    (key, result, user_context),
-                    "feature usage",
-                )
-            except Exception:
-                logger.exception("Error in feature usage callback")
-        return result
+        return core_eval_feature(
+            key=key,
+            evalContext=context,
+            tracking_cb=self._track,
+            feature_usage_cb=self._report_feature_usage,
+        )
+
+    def _report_feature_usage(self, key: str, result: FeatureResult[Any], user_context: UserContext) -> None:
+        if not self.options.on_feature_usage:
+            return
+        try:
+            self._run_user_callback(
+                self.options.on_feature_usage,
+                (key, result, user_context),
+                "feature usage",
+            )
+        except Exception:
+            logger.exception("Error in feature usage callback")
 
     async def is_on(self, key: str, user_context: UserContext) -> bool:
         """Check if a feature is enabled with proper async context management"""
@@ -1250,7 +1252,8 @@ class GrowthBookClient:
         result = run_experiment(
             experiment=experiment,
             evalContext=context,
-            tracking_cb=self._track
+            tracking_cb=self._track,
+            feature_usage_cb=self._report_feature_usage,
         )
         # Fire subscriptions synchronously
         self._fire_subscriptions(experiment, result)

--- a/growthbook/growthbook_client.py
+++ b/growthbook/growthbook_client.py
@@ -1255,6 +1255,7 @@ class GrowthBookClient:
             evalContext=context,
             tracking_cb=self._track,
             feature_usage_cb=self._feature_usage_cb(),
+            callback_subscription=self._fire_subscriptions,
         )
         # Fire subscriptions synchronously
         self._fire_subscriptions(experiment, result)

--- a/tests/test_tracking_telemetry.py
+++ b/tests/test_tracking_telemetry.py
@@ -1,0 +1,191 @@
+"""Exposure and feature-usage reporting for prerequisite and passthrough
+evaluations, and the deferred tracking buffer used to forward exposures."""
+import json
+
+import pytest
+
+from growthbook import GrowthBook
+from growthbook.common_types import Experiment, Options, UserContext
+from growthbook.growthbook_client import GrowthBookClient
+
+# Weights of [1, 0] / [0, 1] make every assignment deterministic.
+FEATURES = {
+    "parent": {
+        "defaultValue": "off",
+        "rules": [
+            {"key": "parent-exp", "coverage": 1, "variations": ["on", "off"], "weights": [1, 0]}
+        ],
+    },
+    "child": {
+        "defaultValue": "child-default",
+        "rules": [
+            {"parentConditions": [{"id": "parent", "condition": {"value": "on"}}], "force": "child-on"}
+        ],
+    },
+    "child-twice": {
+        "defaultValue": "child-default",
+        "rules": [
+            {"parentConditions": [{"id": "parent", "condition": {"value": "nope"}}], "force": "r1"},
+            {"parentConditions": [{"id": "parent", "condition": {"value": "on"}}], "force": "r2"},
+        ],
+    },
+    "ramped": {
+        "defaultValue": "default",
+        "rules": [
+            {
+                "key": "ramp",
+                "coverage": 1,
+                "variations": ["treatment", "default"],
+                "weights": [0, 1],
+                "meta": [{"key": "0"}, {"key": "1", "passthrough": True}],
+            },
+            {"force": "fallthrough"},
+        ],
+    },
+}
+
+
+def make_gb(**kwargs):
+    tracked, usage = [], []
+
+    def on_viewed(experiment, result, user_context):
+        tracked.append((experiment.key, result.variationId))
+
+    def on_usage(key, result, user_context):
+        usage.append(key)
+
+    gb = GrowthBook(
+        attributes={"id": "user-1"},
+        features=FEATURES,
+        on_experiment_viewed=on_viewed,
+        on_feature_usage=on_usage,
+        **kwargs,
+    )
+    return gb, tracked, usage
+
+
+def test_prerequisite_experiment_assignment_is_tracked():
+    gb, tracked, usage = make_gb()
+    res = gb.eval_feature("child")
+    assert res.value == "child-on"
+    assert tracked == [("parent-exp", 0)]
+    assert usage == ["parent", "child"]
+    gb.destroy()
+
+
+def test_experiment_level_prerequisite_is_tracked():
+    gb, tracked, usage = make_gb()
+    exp = Experiment(
+        key="direct",
+        variations=["x", "y"],
+        weights=[1, 0],
+        parentConditions=[{"id": "parent", "condition": {"value": "on"}}],
+    )
+    res = gb.run(exp)
+    assert res.inExperiment and res.value == "x"
+    assert tracked == [("parent-exp", 0), ("direct", 0)]
+    assert usage == ["parent"]
+    gb.destroy()
+
+
+def test_prerequisite_consulted_by_several_rules_is_reported_once():
+    gb, tracked, usage = make_gb()
+    res = gb.eval_feature("child-twice")
+    assert res.value == "r2"
+    assert tracked == [("parent-exp", 0)]
+    assert usage == ["parent", "child-twice"]
+    gb.destroy()
+
+
+def test_passthrough_assignment_is_tracked():
+    gb, tracked, usage = make_gb()
+    res = gb.eval_feature("ramped")
+    assert res.value == "fallthrough"
+    assert tracked == [("ramp", 1)]
+    gb.destroy()
+
+
+def test_deferred_tracking_buffers_when_no_callback():
+    gb = GrowthBook(attributes={"id": "user-1"}, features=FEATURES)
+    gb.eval_feature("child")
+    gb.eval_feature("child")  # same assignment, deduped
+
+    calls = gb.get_deferred_tracking_calls()
+    assert len(calls) == 1
+    assert calls[0]["experiment"]["key"] == "parent-exp"
+    assert calls[0]["result"]["variationId"] == 0
+    assert calls[0]["user"] == {"attributes": {"id": "user-1"}, "url": ""}
+    json.dumps(calls)  # forwardable as-is
+
+    fired = []
+    gb.set_tracking_callback(lambda experiment, result, user_context: fired.append(experiment.key))
+    assert fired == ["parent-exp"]
+    assert gb.get_deferred_tracking_calls() == []
+    gb.destroy()
+
+
+def test_deferred_tracking_calls_can_be_hydrated_and_fired():
+    fired = []
+    gb = GrowthBook(
+        attributes={"id": "user-1"},
+        on_experiment_viewed=lambda experiment, result, user_context: fired.append(
+            (experiment.key, result.variationId)
+        ),
+    )
+    gb.set_deferred_tracking_calls([
+        {
+            "experiment": {"key": "forwarded", "variations": ["a", "b"]},
+            "result": {"variationId": 1, "inExperiment": True, "hashAttribute": "id", "hashValue": "user-1"},
+        },
+        {"experiment": {"key": "missing-variations"}, "result": {}},
+    ])
+    gb.fire_deferred_tracking_calls()
+    assert fired == [("forwarded", 1)]
+    assert gb.get_deferred_tracking_calls() == []
+    gb.destroy()
+
+
+def test_no_buffering_when_callback_configured():
+    gb, tracked, _ = make_gb()
+    gb.eval_feature("child")
+    assert tracked == [("parent-exp", 0)]
+    assert gb.get_deferred_tracking_calls() == []
+    gb.destroy()
+
+
+@pytest.mark.asyncio
+async def test_async_client_buffers_per_user_context():
+    client = GrowthBookClient(Options(api_host="https://localhost.growthbook.io", client_key="test"))
+    await client.set_features(FEATURES)
+    try:
+        user1 = UserContext(attributes={"id": "user-1"})
+        user2 = UserContext(attributes={"id": "user-2"})
+        res = await client.eval_feature("child", user1)
+        assert res.value == "child-on"
+
+        calls = user1.get_deferred_tracking_calls()
+        assert [c["experiment"]["key"] for c in calls] == ["parent-exp"]
+        assert calls[0]["user"]["attributes"] == {"id": "user-1"}
+        assert user2.get_deferred_tracking_calls() == []
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_async_client_tracks_prerequisites_through_callback():
+    tracked, usage = [], []
+    client = GrowthBookClient(Options(
+        api_host="https://localhost.growthbook.io",
+        client_key="test",
+        on_experiment_viewed=lambda experiment, result, user_context: tracked.append(experiment.key),
+        on_feature_usage=lambda key, result, user_context: usage.append(key),
+    ))
+    await client.set_features(FEATURES)
+    try:
+        user = UserContext(attributes={"id": "user-1"})
+        await client.eval_feature("child", user)
+        assert tracked == ["parent-exp"]
+        assert usage == ["parent", "child"]
+        assert user.get_deferred_tracking_calls() == []
+    finally:
+        await client.close()

--- a/tests/test_tracking_telemetry.py
+++ b/tests/test_tracking_telemetry.py
@@ -83,10 +83,13 @@ def test_experiment_level_prerequisite_is_tracked():
         weights=[1, 0],
         parentConditions=[{"id": "parent", "condition": {"value": "on"}}],
     )
+    seen = []
+    gb.subscribe(lambda experiment, result: seen.append(experiment.key))
     res = gb.run(exp)
     assert res.inExperiment and res.value == "x"
     assert tracked == [("parent-exp", 0), ("direct", 0)]
     assert usage == ["parent"]
+    assert seen == ["parent-exp", "direct"]
     gb.destroy()
 
 
@@ -189,13 +192,18 @@ def test_hydration_skips_malformed_entries():
         {"experiment": {"key": "no-variations", "variations": None}, "result": {}},
         {"experiment": {"key": "no-result", "variations": ["a", "b"]}},
         {
+            "experiment": {"key": "bad-user", "variations": ["a", "b"]},
+            "result": {"variationId": 0, "inExperiment": True, "hashAttribute": "id", "hashValue": "user-1"},
+            "user": "not-a-dict",
+        },
+        {
             "experiment": {"key": "forwarded", "variations": ["a", "b"]},
             "result": {"variationId": 1, "inExperiment": True, "hashAttribute": "id", "hashValue": "user-1"},
         },
     ])
-    assert len(gb.get_deferred_tracking_calls()) == 1
+    assert len(gb.get_deferred_tracking_calls()) == 2
     gb.fire_deferred_tracking_calls()
-    assert fired == [("forwarded", 1)]
+    assert fired == [("bad-user", 0), ("forwarded", 1)]
     assert gb.get_deferred_tracking_calls() == []
     gb.destroy()
 

--- a/tests/test_tracking_telemetry.py
+++ b/tests/test_tracking_telemetry.py
@@ -1,5 +1,6 @@
 """Exposure and feature-usage reporting for prerequisite and passthrough
 evaluations, and the deferred tracking buffer used to forward exposures."""
+import dataclasses
 import json
 
 import pytest
@@ -42,6 +43,7 @@ FEATURES = {
             {"force": "fallthrough"},
         ],
     },
+    "unserializable": {"defaultValue": {1: "a", "b": 2}},
 }
 
 
@@ -105,8 +107,36 @@ def test_passthrough_assignment_is_tracked():
     gb.destroy()
 
 
-def test_deferred_tracking_buffers_when_no_callback():
+def test_subscriptions_see_prerequisite_experiments():
+    gb, _, _ = make_gb()
+    seen = []
+    gb.subscribe(lambda experiment, result: seen.append(experiment.key))
+    gb.eval_feature("child")
+    assert seen == ["parent-exp"]
+    assert "parent-exp" in gb.get_all_results()
+    gb.destroy()
+
+
+def test_unserializable_feature_values_do_not_break_evaluation():
+    gb, _, usage = make_gb()
+    assert gb.eval_feature("unserializable").value == {1: "a", "b": 2}
+    assert usage == ["unserializable"]
+    gb.destroy()
+
+    silent = GrowthBook(attributes={"id": "user-1"}, features=FEATURES)
+    assert silent.eval_feature("unserializable").value == {1: "a", "b": 2}
+    silent.destroy()
+
+
+def test_deferred_tracking_is_opt_in():
     gb = GrowthBook(attributes={"id": "user-1"}, features=FEATURES)
+    gb.eval_feature("child")
+    assert gb.get_deferred_tracking_calls() == []
+    gb.destroy()
+
+
+def test_deferred_tracking_buffers_when_no_callback():
+    gb = GrowthBook(attributes={"id": "user-1"}, features=FEATURES, defer_tracking=True)
     gb.eval_feature("child")
     gb.eval_feature("child")  # same assignment, deduped
 
@@ -124,6 +154,21 @@ def test_deferred_tracking_buffers_when_no_callback():
     gb.destroy()
 
 
+def test_replay_uses_the_buffered_user():
+    gb = GrowthBook(attributes={"id": "user-1"}, features=FEATURES, defer_tracking=True)
+    gb.eval_feature("child")
+    gb.set_attributes({"id": "user-2"})
+    gb.eval_feature("child")
+    gb.set_attributes({"id": "user-3"})
+
+    seen = []
+    gb.set_tracking_callback(
+        lambda experiment, result, user_context: seen.append((result.hashValue, user_context.attributes["id"]))
+    )
+    assert seen == [("user-1", "user-1"), ("user-2", "user-2")]
+    gb.destroy()
+
+
 def test_deferred_tracking_calls_can_be_hydrated_and_fired():
     fired = []
     gb = GrowthBook(
@@ -133,24 +178,63 @@ def test_deferred_tracking_calls_can_be_hydrated_and_fired():
         ),
     )
     gb.set_deferred_tracking_calls([
+        None,
+        {"experiment": {"key": 123, "variations": ["a"]}, "result": {}},
+        {"experiment": {"key": "no-variations", "variations": None}, "result": {}},
+        {"experiment": {"key": "no-result", "variations": ["a", "b"]}},
         {
             "experiment": {"key": "forwarded", "variations": ["a", "b"]},
             "result": {"variationId": 1, "inExperiment": True, "hashAttribute": "id", "hashValue": "user-1"},
         },
-        {"experiment": {"key": "missing-variations"}, "result": {}},
     ])
+    assert len(gb.get_deferred_tracking_calls()) == 1
     gb.fire_deferred_tracking_calls()
     assert fired == [("forwarded", 1)]
     assert gb.get_deferred_tracking_calls() == []
     gb.destroy()
 
 
+def test_replay_keeps_entries_the_callback_raised_on():
+    gb = GrowthBook(attributes={"id": "user-1"}, features=FEATURES, defer_tracking=True)
+    gb.eval_feature("child")
+    gb.eval_feature("ramped")
+    assert len(gb.get_deferred_tracking_calls()) == 2
+
+    def flaky(experiment, result, user_context):
+        if experiment.key == "ramp":
+            raise RuntimeError("analytics down")
+
+    gb.set_tracking_callback(flaky)
+    remaining = gb.get_deferred_tracking_calls()
+    assert [c["experiment"]["key"] for c in remaining] == ["ramp"]
+    gb.destroy()
+
+
 def test_no_buffering_when_callback_configured():
-    gb, tracked, _ = make_gb()
+    gb, tracked, _ = make_gb(defer_tracking=True)
     gb.eval_feature("child")
     assert tracked == [("parent-exp", 0)]
     assert gb.get_deferred_tracking_calls() == []
     gb.destroy()
+
+
+def test_user_context_buffer_is_not_a_dataclass_field():
+    ctx = UserContext(attributes={"id": "u"}, defer_tracking=True)
+    ctx.defer_tracking_call(Experiment(key="e", variations=["a", "b"]), _result())
+    assert len(ctx.get_deferred_tracking_calls()) == 1
+
+    rebuilt = UserContext(**dataclasses.asdict(ctx))
+    assert rebuilt.defer_tracking is True
+    assert rebuilt.get_deferred_tracking_calls() == []
+    assert dataclasses.replace(ctx).get_deferred_tracking_calls() == []
+
+
+def _result():
+    from growthbook.common_types import Result
+
+    return Result(
+        variationId=0, inExperiment=True, value="a", hashUsed=True, hashAttribute="id", hashValue="u", featureId=None
+    )
 
 
 @pytest.mark.asyncio
@@ -158,8 +242,8 @@ async def test_async_client_buffers_per_user_context():
     client = GrowthBookClient(Options(api_host="https://localhost.growthbook.io", client_key="test"))
     await client.set_features(FEATURES)
     try:
-        user1 = UserContext(attributes={"id": "user-1"})
-        user2 = UserContext(attributes={"id": "user-2"})
+        user1 = UserContext(attributes={"id": "user-1"}, defer_tracking=True)
+        user2 = UserContext(attributes={"id": "user-2"}, defer_tracking=True)
         res = await client.eval_feature("child", user1)
         assert res.value == "child-on"
 
@@ -182,7 +266,7 @@ async def test_async_client_tracks_prerequisites_through_callback():
     ))
     await client.set_features(FEATURES)
     try:
-        user = UserContext(attributes={"id": "user-1"})
+        user = UserContext(attributes={"id": "user-1"}, defer_tracking=True)
         await client.eval_feature("child", user)
         assert tracked == ["parent-exp"]
         assert usage == ["parent", "child"]

--- a/tests/test_tracking_telemetry.py
+++ b/tests/test_tracking_telemetry.py
@@ -6,7 +6,7 @@ import json
 import pytest
 
 from growthbook import GrowthBook
-from growthbook.common_types import Experiment, Options, UserContext
+from growthbook.common_types import Experiment, Options, Result, UserContext
 from growthbook.growthbook_client import GrowthBookClient
 
 # Weights of [1, 0] / [0, 1] make every assignment deterministic.
@@ -123,10 +123,6 @@ def test_unserializable_feature_values_do_not_break_evaluation():
     assert usage == ["unserializable"]
     gb.destroy()
 
-    silent = GrowthBook(attributes={"id": "user-1"}, features=FEATURES)
-    assert silent.eval_feature("unserializable").value == {1: "a", "b": 2}
-    silent.destroy()
-
 
 def test_deferred_tracking_is_opt_in():
     gb = GrowthBook(attributes={"id": "user-1"}, features=FEATURES)
@@ -146,30 +142,40 @@ def test_deferred_tracking_buffers_when_no_callback():
     assert calls[0]["result"]["variationId"] == 0
     assert calls[0]["user"] == {"attributes": {"id": "user-1"}, "url": ""}
     json.dumps(calls)  # forwardable as-is
-
-    fired = []
-    gb.set_tracking_callback(lambda experiment, result, user_context: fired.append(experiment.key))
-    assert fired == ["parent-exp"]
-    assert gb.get_deferred_tracking_calls() == []
     gb.destroy()
 
 
-def test_replay_uses_the_buffered_user():
-    gb = GrowthBook(attributes={"id": "user-1"}, features=FEATURES, defer_tracking=True)
+def test_buffering_is_independent_of_the_callback():
+    gb, tracked, _ = make_gb(defer_tracking=True)
     gb.eval_feature("child")
-    gb.set_attributes({"id": "user-2"})
-    gb.eval_feature("child")
-    gb.set_attributes({"id": "user-3"})
+    assert tracked == [("parent-exp", 0)]
+    assert [c["experiment"]["key"] for c in gb.get_deferred_tracking_calls()] == ["parent-exp"]
+    gb.destroy()
+
+
+def test_forwarded_calls_replay_with_their_own_user():
+    sender = GrowthBook(attributes={"id": "user-1"}, features=FEATURES, defer_tracking=True)
+    sender.eval_feature("child")
+    sender.set_attributes({"id": "user-2"})
+    sender.eval_feature("child")
+    forwarded = json.loads(json.dumps(sender.get_deferred_tracking_calls()))
+    sender.destroy()
 
     seen = []
-    gb.set_tracking_callback(
-        lambda experiment, result, user_context: seen.append((result.hashValue, user_context.attributes["id"]))
+    receiver = GrowthBook(
+        attributes={"id": "receiver"},
+        on_experiment_viewed=lambda experiment, result, user_context: seen.append(
+            (result.hashValue, user_context.attributes["id"])
+        ),
     )
+    receiver.set_deferred_tracking_calls(forwarded)
+    receiver.fire_deferred_tracking_calls()
     assert seen == [("user-1", "user-1"), ("user-2", "user-2")]
-    gb.destroy()
+    assert receiver.get_deferred_tracking_calls() == []
+    receiver.destroy()
 
 
-def test_deferred_tracking_calls_can_be_hydrated_and_fired():
+def test_hydration_skips_malformed_entries():
     fired = []
     gb = GrowthBook(
         attributes={"id": "user-1"},
@@ -195,46 +201,35 @@ def test_deferred_tracking_calls_can_be_hydrated_and_fired():
 
 
 def test_replay_keeps_entries_the_callback_raised_on():
-    gb = GrowthBook(attributes={"id": "user-1"}, features=FEATURES, defer_tracking=True)
-    gb.eval_feature("child")
-    gb.eval_feature("ramped")
-    assert len(gb.get_deferred_tracking_calls()) == 2
+    sender = GrowthBook(attributes={"id": "user-1"}, features=FEATURES, defer_tracking=True)
+    sender.eval_feature("child")
+    sender.eval_feature("ramped")
+    calls = sender.get_deferred_tracking_calls()
+    sender.destroy()
 
     def flaky(experiment, result, user_context):
         if experiment.key == "ramp":
             raise RuntimeError("analytics down")
 
-    gb.set_tracking_callback(flaky)
-    remaining = gb.get_deferred_tracking_calls()
-    assert [c["experiment"]["key"] for c in remaining] == ["ramp"]
-    gb.destroy()
-
-
-def test_no_buffering_when_callback_configured():
-    gb, tracked, _ = make_gb(defer_tracking=True)
-    gb.eval_feature("child")
-    assert tracked == [("parent-exp", 0)]
-    assert gb.get_deferred_tracking_calls() == []
-    gb.destroy()
+    receiver = GrowthBook(attributes={"id": "receiver"}, on_experiment_viewed=flaky)
+    receiver.set_deferred_tracking_calls(calls)
+    receiver.fire_deferred_tracking_calls()
+    assert [c["experiment"]["key"] for c in receiver.get_deferred_tracking_calls()] == ["ramp"]
+    receiver.destroy()
 
 
 def test_user_context_buffer_is_not_a_dataclass_field():
     ctx = UserContext(attributes={"id": "u"}, defer_tracking=True)
-    ctx.defer_tracking_call(Experiment(key="e", variations=["a", "b"]), _result())
+    result = Result(
+        variationId=0, inExperiment=True, value="a", hashUsed=True, hashAttribute="id", hashValue="u", featureId=None
+    )
+    ctx.defer_tracking_call(Experiment(key="e", variations=["a", "b"]), result)
     assert len(ctx.get_deferred_tracking_calls()) == 1
 
     rebuilt = UserContext(**dataclasses.asdict(ctx))
     assert rebuilt.defer_tracking is True
     assert rebuilt.get_deferred_tracking_calls() == []
     assert dataclasses.replace(ctx).get_deferred_tracking_calls() == []
-
-
-def _result():
-    from growthbook.common_types import Result
-
-    return Result(
-        variationId=0, inExperiment=True, value="a", hashUsed=True, hashAttribute="id", hashValue="u", featureId=None
-    )
 
 
 @pytest.mark.asyncio
@@ -266,7 +261,7 @@ async def test_async_client_tracks_prerequisites_through_callback():
     ))
     await client.set_features(FEATURES)
     try:
-        user = UserContext(attributes={"id": "user-1"}, defer_tracking=True)
+        user = UserContext(attributes={"id": "user-1"})
         await client.eval_feature("child", user)
         assert tracked == ["parent-exp"]
         assert usage == ["parent", "child"]


### PR DESCRIPTION
### What this fixes and adds

**Prerequisite telemetry.** Experiments that decide a prerequisite feature now fire `on_experiment_viewed` — previously `eval_prereqs` dropped the tracking callback, so those exposures were silently lost. `on_feature_usage` fires for every feature evaluated, prerequisites included (once per evaluation), and subscriptions see prerequisite experiments too. Passthrough assignments were already tracked and stay that way.

**Deferred tracking (opt-in).** `defer_tracking=True` buffers each exposure as a `{experiment, result, user}` dict in the JS SDK's shape, for servers that forward tracking to client SDKs. On `GrowthBook` read them with `get_deferred_tracking_calls()`; on `GrowthBookClient` the buffer lives on each `UserContext(defer_tracking=True)` so requests never mix. The receiving side loads them with `set_deferred_tracking_calls()` and sends them through its callback with `fire_deferred_tracking_calls()`, each with the user it was recorded for. Buffering is independent of callbacks, matching the Go SDK. Verified end-to-end into a JS client's `setDeferredTrackingCalls`.

The tracking dedupe key is shared by both clients and separator-delimited, so distinct exposures can't collide on field boundaries.

### Testing

New `tests/test_tracking_telemetry.py`: prerequisite tracking and usage at rule and experiment level, once-per-evaluation dedupe, passthrough, subscriptions, unserializable values, opt-in default, buffering alongside a callback, forward-and-replay with per-user fidelity, malformed-entry hydration, failed-callback retention, `UserContext` asdict/replace round-trips, and per-`UserContext` isolation on the async client. Full suite passes; mypy clean; pyright unchanged vs `main`.
