### PR TITLE
fix: empty variations or short meta in a rule crashed evaluation with IndexError

### DIFF
--- a/growthbook/core.py
+++ b/growthbook/core.py
@@ -1417,8 +1417,12 @@ def _getExperimentResult(
         variationId = 0
         inExperiment = False
 
+    # A meta list shorter than the variations list is a malformed payload:
+    # treat the missing entry as absent instead of raising. (The JS SDK
+    # crashes here too — reading `.key` off undefined — so this is a
+    # deliberate divergence on invalid payloads only.)
     meta = None
-    if experiment.meta:
+    if experiment.meta and variationId < len(experiment.meta):
         meta = experiment.meta[variationId]
 
     (hashAttribute, hashValue) = _getOrigHashValue(attr=experiment.hashAttribute,
@@ -1436,11 +1440,18 @@ def _getExperimentResult(
         variation_weights = cb["variationWeights"]
         bandit_version = cb.get("banditVersion")
 
+    # The clamp above leaves variationId at 0 even when the variations list is
+    # empty (a malformed payload — e.g. `variations: []` or
+    # `contextualVariations: []`). The JS SDK reads `undefined` there and the
+    # rule degrades to the feature's default; mirror it with None instead of
+    # raising IndexError.
+    value = experiment.variations[variationId] if experiment.variations else None
+
     return Result(
         featureId=featureId,
         inExperiment=inExperiment,
         variationId=variationId,
-        value=experiment.variations[variationId],
+        value=value,
         hashUsed=hashUsed,
         hashAttribute=hashAttribute,
         hashValue=hashValue,

--- a/tests/test_growthbook.py
+++ b/tests/test_growthbook.py
@@ -413,6 +413,62 @@ def test_handles_weird_experiment_values():
     gb.destroy()
 
 
+def test_empty_variations_rule_serves_default():
+    """A rule with an empty variations list is a malformed payload: the JS SDK
+    reads `undefined` as the clamped variation's value, marks the result not
+    in-experiment, and serves the feature default. Python used to raise an
+    uncaught IndexError instead."""
+    gb = GrowthBook(
+        attributes={"id": "1"},
+        features={"f": {"defaultValue": "x", "rules": [{"key": "exp", "variations": []}]}},
+    )
+    res = gb.eval_feature("f")
+    assert res.value == "x"
+    assert res.source == "defaultValue"
+
+    # Same guard for the public run() API.
+    result = gb.run(Experiment(key="direct", variations=[]))
+    assert result.inExperiment is False
+    assert result.value is None
+    gb.destroy()
+
+
+def test_empty_contextual_variations_rule_serves_default():
+    """Same malformed shape through the contextual bandit door
+    (`contextualVariations: []`)."""
+    gb = GrowthBook(
+        attributes={"id": "1"},
+        features={"f": {"defaultValue": "x", "rules": [{
+            "key": "exp", "seed": "s", "hashVersion": 2, "hashAttribute": "id",
+            "contextualVariations": [], "weights": [], "contextualBanditRef": "cb1",
+        }]}},
+        contextualBandits={"cb1": {"contexts": []}},
+    )
+    res = gb.eval_feature("f")
+    assert res.value == "x"
+    assert res.source == "defaultValue"
+    gb.destroy()
+
+
+def test_meta_shorter_than_variations_does_not_crash():
+    """A meta list shorter than the variations list is a malformed payload:
+    the missing entry reads as absent (result key falls back to the variation
+    id) instead of raising IndexError. Deliberately stricter than the JS SDK,
+    which crashes reading `.key` off undefined here."""
+    gb = GrowthBook(
+        attributes={"id": "1"},
+        features={"m": {"defaultValue": "x", "rules": [{
+            "key": "exp-meta", "variations": ["a", "b"], "weights": [0, 1],
+            "meta": [{"key": "control"}],
+        }]}},
+    )
+    res = gb.eval_feature("m")
+    assert res.value == "b"
+    assert res.experimentResult.variationId == 1
+    assert res.experimentResult.key == "1"
+    gb.destroy()
+
+
 def test_experiment_to_dict_preserves_explicit_zero_coverage():
     # `or 1` would coerce a real coverage of 0 to 1; None still reads as
     # full coverage. Serialized dicts are forwarded (deferred tracking),


### PR DESCRIPTION
## Summary
`_getExperimentResult` raised an uncaught `IndexError` on two malformed payload shapes; both now degrade the way the evaluation contract expects instead of crashing feature evaluation.

## Root cause
The out-of-range clamp sets `variationId = 0` and then indexes unconditionally:

- `variations: []` (or `contextualVariations: []` on a bandit rule) → `experiment.variations[0]` → `IndexError` at core.py:1443. Pre-existing, not a bandit regression — reproduced on v3.0.0 with a plain `variations: []` rule; the CB shape is just a second door into it.
- `meta` shorter than `variations` (e.g. 2 variations, 1 meta entry, user hashes into variation 1) → `experiment.meta[1]` → `IndexError` at core.py:1422.

## Behavioral change
- Empty variations: the clamped variation's value reads as `None` (the JS SDK reads `undefined` there), the result stays `inExperiment=False`, and the rule falls through to the feature's `defaultValue` — identical user-visible behavior to JS.
- Short meta: the missing entry reads as absent (result `key` falls back to the variation id). The JS SDK crashes here too (`.key` off `undefined`), so this half is a deliberate Python-stricter divergence on invalid payloads only.

## Follow-ups
- Propose an empty-variations case for the shared `cases.json` corpus (JS repo) so all SDKs pin the fall-through behavior.
- JS fix for the short-meta `TypeError` (same latent crash in `getExperimentResult`).

## Test plan
- [x] New tests fail without the fix, pass with it: `pytest tests/test_growthbook.py -k "empty_variations or empty_contextual or meta_shorter"`
- [x] Full suite: `pytest tests/ -q` — 972 passed (2 known local-env `test_typing[*-mypy]` deselects)
- [x] mypy at baseline (1 pre-existing urllib3 error), pyright 0 errors, flake8 `--select=E9,F63,F7,F82` clean
